### PR TITLE
fix: update library name

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+### 📰 Summary of changes
+<!-- Feel free to delete this section if it doesn't apply -->
+> What is the new functionality added in this PR?
+
+### 🧪 Testing done
+<!-- Feel free to delete this section if it doesn't apply -->
+> What testing was added to cover the functionality added in this PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+- Correct library name
+
 ## 0.0.1
 
 - Initial version

--- a/lib/sturdy_http.dart
+++ b/lib/sturdy_http.dart
@@ -1,4 +1,4 @@
-library http_client;
+library sturdy_http;
 
 export 'src/_dio_error.dart';
 export 'src/sturdy_http.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sturdy_http
 description: A strongly typed, event-based, reliable HTTP client that wraps `Dio.
-version: 0.0.1
+version: 0.0.2
 homepage: https://github.com/Betterment/sturdy_http
 repository: https://github.com/Betterment/sturdy_http
 


### PR DESCRIPTION
### 📰 Summary of changes
<!-- Feel free to delete this section if it doesn't apply -->
> What is the new functionality added in this PR?

Noticed that I missed the `library` name when changing the name from `HttpClient` to `SturdyHttp` 🤦 . Changing that here along with a couple other cleanup tasks.