### PR TITLE
feat: add ability to provide cancel token, send & receive progress callbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
       - name: Setup dart
         uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f # v1.5.0
+        with:
+          sdk: 2.18.5
       - name: Install dependencies
         run: |
           dart pub get

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
       - name: Setup dart
         uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f # v1.5.0
+        with:
+          sdk: 2.18.5
       - name: Install dependencies
         run: dart pub get
       - name: Verify formatting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.0.3
+## 0.1.0
 
 - Add ability to provide `CancelToken` as well as send and receive progress callbacks to `NetworkRequest`s
+
 ## 0.0.2
 
 - Correct library name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 0.1.0
 
 - Add ability to provide `CancelToken` as well as send and receive progress callbacks to `NetworkRequest`s
+- Remove ability to provide `headers` to `NetworkRequest`s. Instead, pass `Options`.
+- Migrate to `DioException` from the deprecated `DioError`.
+- Remove proxy configuration on the underlying `Dio` instance during construction of `SturdyHttp`. If you want to configure proxy information, do it via an `Interceptor`.
 
 ## 0.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.3
+
+- Add ability to provide `CancelToken` as well as send and receive progress callbacks to `NetworkRequest`s
 ## 0.0.2
 
 - Correct library name

--- a/lib/src/_dio_error.dart
+++ b/lib/src/_dio_error.dart
@@ -3,19 +3,19 @@ import 'dart:io';
 import 'package:dio/dio.dart';
 
 // ignore: public_member_api_docs
-extension DioErrorX on DioError {
-  /// Indicates whether we have reason to believe a [DioError] occurred
+extension DioExceptionX on DioException {
+  /// Indicates whether we have reason to believe a [DioException] occurred
   /// because of an issue with the internet connection. These checks/values
   /// are mostly curated through experience with Sentry issues and a sprinkle
   /// of common sense. If we have reason to believe we're over or under
-  /// capturing [DioErrorType]s or [Exception] types we can adjust the logic.
+  /// capturing [DioExceptionType]s or [Exception] types we can adjust the logic.
   bool isConnectionIssue() {
     const knownBadConnectionTypes = [
-      DioErrorType.connectionError,
-      DioErrorType.connectionTimeout,
-      DioErrorType.receiveTimeout,
-      DioErrorType.sendTimeout,
-      DioErrorType.unknown,
+      DioExceptionType.connectionError,
+      DioExceptionType.connectionTimeout,
+      DioExceptionType.receiveTimeout,
+      DioExceptionType.sendTimeout,
+      DioExceptionType.unknown,
     ];
     final isKnownExceptionType = error is HandshakeException ||
         error is SocketException ||

--- a/lib/src/network_request.dart
+++ b/lib/src/network_request.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:sturdy_http/sturdy_http.dart';
 
@@ -25,7 +26,10 @@ abstract class NetworkRequest {
     required this.data,
     required this.shouldTriggerDataMutation,
     this.queryParams,
-    this.headers,
+    this.options,
+    this.cancelToken,
+    this.onReceiveProgress,
+    this.onSendProgress,
   });
 
   /// {@macro network_request_type}
@@ -45,8 +49,17 @@ abstract class NetworkRequest {
   /// Query parameters for this request
   final Map<String, dynamic>? queryParams;
 
-  /// Headers for this request
-  final Map<String, String>? headers;
+  /// [Options] for this request
+  final Options? options;
+
+  /// [CancelToken] for this request
+  final CancelToken? cancelToken;
+
+  /// [ProgressCallback] for receive progress for this request
+  final ProgressCallback? onReceiveProgress;
+
+  /// [ProgressCallback] for send progress for this request
+  final ProgressCallback? onSendProgress;
 }
 
 /// {@template get_request}
@@ -58,7 +71,9 @@ class GetRequest extends NetworkRequest {
     String path, {
     super.data = const NetworkRequestBody.empty(),
     Map<String, dynamic>? queryParameters,
-    super.headers,
+    super.options,
+    super.onReceiveProgress,
+    super.onSendProgress,
   }) : super(
           type: NetworkRequestType.Get,
           path: path,
@@ -77,7 +92,9 @@ class PostRequest extends NetworkRequest {
     required super.data,
     Map<String, dynamic>? queryParameters,
     super.shouldTriggerDataMutation = true,
-    super.headers,
+    super.options,
+    super.onReceiveProgress,
+    super.onSendProgress,
   }) : super(
           type: NetworkRequestType.Post,
           path: path,
@@ -95,7 +112,9 @@ class PutRequest extends NetworkRequest {
     required super.data,
     Map<String, dynamic>? queryParameters,
     super.shouldTriggerDataMutation = true,
-    super.headers,
+    super.options,
+    super.onReceiveProgress,
+    super.onSendProgress,
   }) : super(
           type: NetworkRequestType.Put,
           path: path,
@@ -113,7 +132,9 @@ class DeleteRequest extends NetworkRequest {
     super.data = const NetworkRequestBody.empty(),
     Map<String, dynamic>? queryParameters,
     super.shouldTriggerDataMutation = true,
-    super.headers,
+    super.options,
+    super.onReceiveProgress,
+    super.onSendProgress,
   }) : super(
           type: NetworkRequestType.Delete,
           path: path,

--- a/lib/src/network_request.dart
+++ b/lib/src/network_request.dart
@@ -72,6 +72,7 @@ class GetRequest extends NetworkRequest {
     super.data = const NetworkRequestBody.empty(),
     Map<String, dynamic>? queryParameters,
     super.options,
+    super.cancelToken,
     super.onReceiveProgress,
     super.onSendProgress,
   }) : super(
@@ -93,6 +94,7 @@ class PostRequest extends NetworkRequest {
     Map<String, dynamic>? queryParameters,
     super.shouldTriggerDataMutation = true,
     super.options,
+    super.cancelToken,
     super.onReceiveProgress,
     super.onSendProgress,
   }) : super(
@@ -113,6 +115,7 @@ class PutRequest extends NetworkRequest {
     Map<String, dynamic>? queryParameters,
     super.shouldTriggerDataMutation = true,
     super.options,
+    super.cancelToken,
     super.onReceiveProgress,
     super.onSendProgress,
   }) : super(
@@ -133,6 +136,7 @@ class DeleteRequest extends NetworkRequest {
     Map<String, dynamic>? queryParameters,
     super.shouldTriggerDataMutation = true,
     super.options,
+    super.cancelToken,
     super.onReceiveProgress,
     super.onSendProgress,
   }) : super(

--- a/lib/src/network_response.dart
+++ b/lib/src/network_response.dart
@@ -21,39 +21,40 @@ class NetworkResponse<R> with _$NetworkResponse<R> {
   const factory NetworkResponse.okNoContent() = _OkNoContent;
 
   /// 401 - for responses when the request was missing required authentication.
-  const factory NetworkResponse.unauthorized(DioError error) = _Unauthorized;
+  const factory NetworkResponse.unauthorized(DioException error) =
+      _Unauthorized;
 
   /// 403 - for responses when the request was authenticated but the
   /// action is not authorized/allowed.
-  const factory NetworkResponse.forbidden(DioError error) = _Forbidden;
+  const factory NetworkResponse.forbidden(DioException error) = _Forbidden;
 
   /// 404 - for responses when we could not locate a resource, or when
   /// someone would attempt to access a forbidden resource due to a bug.
-  const factory NetworkResponse.notFound(DioError error) = _NotFound;
+  const factory NetworkResponse.notFound(DioException error) = _NotFound;
 
   /// 422 - for responses when the request inputs failed our validations.
   const factory NetworkResponse.unprocessableEntity({
-    required DioError error,
+    required DioException error,
     required R response,
   }) = _UnprocessableEntity;
 
   /// 500 - for responses where the service had an error while processing
   /// the request.
-  const factory NetworkResponse.serverError(DioError error) = _ServerError;
+  const factory NetworkResponse.serverError(DioException error) = _ServerError;
 
   /// 503 - for responses when an underlying service issue prevents us from
   /// fulfilling the request.
-  const factory NetworkResponse.serviceUnavailable(DioError error) =
+  const factory NetworkResponse.serviceUnavailable(DioException error) =
       _ServiceUnavailable;
 
   /// An error designated as a fallback in the event that we receive a status code
   /// we don't explicitly handle *or* a request or response otherwise fails to meet
   /// our expectations as "valid". The [message] will describe the condition and a
-  /// [DioError] will be present if it was available as a result of the request.
+  /// [DioException] will be present if it was available as a result of the request.
   const factory NetworkResponse.genericError({
     required String message,
     required bool isConnectionIssue,
-    DioError? error,
+    DioException? error,
   }) = _GenericError;
 }
 

--- a/lib/src/network_response.freezed.dart
+++ b/lib/src/network_response.freezed.dart
@@ -20,14 +20,15 @@ mixin _$NetworkResponse<R> {
   TResult when<TResult extends Object?>({
     required TResult Function(R response) ok,
     required TResult Function() okNoContent,
-    required TResult Function(DioError error) unauthorized,
-    required TResult Function(DioError error) forbidden,
-    required TResult Function(DioError error) notFound,
-    required TResult Function(DioError error, R response) unprocessableEntity,
-    required TResult Function(DioError error) serverError,
-    required TResult Function(DioError error) serviceUnavailable,
+    required TResult Function(DioException error) unauthorized,
+    required TResult Function(DioException error) forbidden,
+    required TResult Function(DioException error) notFound,
+    required TResult Function(DioException error, R response)
+        unprocessableEntity,
+    required TResult Function(DioException error) serverError,
+    required TResult Function(DioException error) serviceUnavailable,
     required TResult Function(
-            String message, bool isConnectionIssue, DioError? error)
+            String message, bool isConnectionIssue, DioException? error)
         genericError,
   }) =>
       throw _privateConstructorUsedError;
@@ -35,13 +36,14 @@ mixin _$NetworkResponse<R> {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(R response)? ok,
     TResult? Function()? okNoContent,
-    TResult? Function(DioError error)? unauthorized,
-    TResult? Function(DioError error)? forbidden,
-    TResult? Function(DioError error)? notFound,
-    TResult? Function(DioError error, R response)? unprocessableEntity,
-    TResult? Function(DioError error)? serverError,
-    TResult? Function(DioError error)? serviceUnavailable,
-    TResult? Function(String message, bool isConnectionIssue, DioError? error)?
+    TResult? Function(DioException error)? unauthorized,
+    TResult? Function(DioException error)? forbidden,
+    TResult? Function(DioException error)? notFound,
+    TResult? Function(DioException error, R response)? unprocessableEntity,
+    TResult? Function(DioException error)? serverError,
+    TResult? Function(DioException error)? serviceUnavailable,
+    TResult? Function(
+            String message, bool isConnectionIssue, DioException? error)?
         genericError,
   }) =>
       throw _privateConstructorUsedError;
@@ -49,13 +51,14 @@ mixin _$NetworkResponse<R> {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(R response)? ok,
     TResult Function()? okNoContent,
-    TResult Function(DioError error)? unauthorized,
-    TResult Function(DioError error)? forbidden,
-    TResult Function(DioError error)? notFound,
-    TResult Function(DioError error, R response)? unprocessableEntity,
-    TResult Function(DioError error)? serverError,
-    TResult Function(DioError error)? serviceUnavailable,
-    TResult Function(String message, bool isConnectionIssue, DioError? error)?
+    TResult Function(DioException error)? unauthorized,
+    TResult Function(DioException error)? forbidden,
+    TResult Function(DioException error)? notFound,
+    TResult Function(DioException error, R response)? unprocessableEntity,
+    TResult Function(DioException error)? serverError,
+    TResult Function(DioException error)? serviceUnavailable,
+    TResult Function(
+            String message, bool isConnectionIssue, DioException? error)?
         genericError,
     required TResult orElse(),
   }) =>
@@ -186,14 +189,15 @@ class _$_Ok<R> implements _Ok<R> {
   TResult when<TResult extends Object?>({
     required TResult Function(R response) ok,
     required TResult Function() okNoContent,
-    required TResult Function(DioError error) unauthorized,
-    required TResult Function(DioError error) forbidden,
-    required TResult Function(DioError error) notFound,
-    required TResult Function(DioError error, R response) unprocessableEntity,
-    required TResult Function(DioError error) serverError,
-    required TResult Function(DioError error) serviceUnavailable,
+    required TResult Function(DioException error) unauthorized,
+    required TResult Function(DioException error) forbidden,
+    required TResult Function(DioException error) notFound,
+    required TResult Function(DioException error, R response)
+        unprocessableEntity,
+    required TResult Function(DioException error) serverError,
+    required TResult Function(DioException error) serviceUnavailable,
     required TResult Function(
-            String message, bool isConnectionIssue, DioError? error)
+            String message, bool isConnectionIssue, DioException? error)
         genericError,
   }) {
     return ok(response);
@@ -204,13 +208,14 @@ class _$_Ok<R> implements _Ok<R> {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(R response)? ok,
     TResult? Function()? okNoContent,
-    TResult? Function(DioError error)? unauthorized,
-    TResult? Function(DioError error)? forbidden,
-    TResult? Function(DioError error)? notFound,
-    TResult? Function(DioError error, R response)? unprocessableEntity,
-    TResult? Function(DioError error)? serverError,
-    TResult? Function(DioError error)? serviceUnavailable,
-    TResult? Function(String message, bool isConnectionIssue, DioError? error)?
+    TResult? Function(DioException error)? unauthorized,
+    TResult? Function(DioException error)? forbidden,
+    TResult? Function(DioException error)? notFound,
+    TResult? Function(DioException error, R response)? unprocessableEntity,
+    TResult? Function(DioException error)? serverError,
+    TResult? Function(DioException error)? serviceUnavailable,
+    TResult? Function(
+            String message, bool isConnectionIssue, DioException? error)?
         genericError,
   }) {
     return ok?.call(response);
@@ -221,13 +226,14 @@ class _$_Ok<R> implements _Ok<R> {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(R response)? ok,
     TResult Function()? okNoContent,
-    TResult Function(DioError error)? unauthorized,
-    TResult Function(DioError error)? forbidden,
-    TResult Function(DioError error)? notFound,
-    TResult Function(DioError error, R response)? unprocessableEntity,
-    TResult Function(DioError error)? serverError,
-    TResult Function(DioError error)? serviceUnavailable,
-    TResult Function(String message, bool isConnectionIssue, DioError? error)?
+    TResult Function(DioException error)? unauthorized,
+    TResult Function(DioException error)? forbidden,
+    TResult Function(DioException error)? notFound,
+    TResult Function(DioException error, R response)? unprocessableEntity,
+    TResult Function(DioException error)? serverError,
+    TResult Function(DioException error)? serviceUnavailable,
+    TResult Function(
+            String message, bool isConnectionIssue, DioException? error)?
         genericError,
     required TResult orElse(),
   }) {
@@ -340,14 +346,15 @@ class _$_OkNoContent<R> implements _OkNoContent<R> {
   TResult when<TResult extends Object?>({
     required TResult Function(R response) ok,
     required TResult Function() okNoContent,
-    required TResult Function(DioError error) unauthorized,
-    required TResult Function(DioError error) forbidden,
-    required TResult Function(DioError error) notFound,
-    required TResult Function(DioError error, R response) unprocessableEntity,
-    required TResult Function(DioError error) serverError,
-    required TResult Function(DioError error) serviceUnavailable,
+    required TResult Function(DioException error) unauthorized,
+    required TResult Function(DioException error) forbidden,
+    required TResult Function(DioException error) notFound,
+    required TResult Function(DioException error, R response)
+        unprocessableEntity,
+    required TResult Function(DioException error) serverError,
+    required TResult Function(DioException error) serviceUnavailable,
     required TResult Function(
-            String message, bool isConnectionIssue, DioError? error)
+            String message, bool isConnectionIssue, DioException? error)
         genericError,
   }) {
     return okNoContent();
@@ -358,13 +365,14 @@ class _$_OkNoContent<R> implements _OkNoContent<R> {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(R response)? ok,
     TResult? Function()? okNoContent,
-    TResult? Function(DioError error)? unauthorized,
-    TResult? Function(DioError error)? forbidden,
-    TResult? Function(DioError error)? notFound,
-    TResult? Function(DioError error, R response)? unprocessableEntity,
-    TResult? Function(DioError error)? serverError,
-    TResult? Function(DioError error)? serviceUnavailable,
-    TResult? Function(String message, bool isConnectionIssue, DioError? error)?
+    TResult? Function(DioException error)? unauthorized,
+    TResult? Function(DioException error)? forbidden,
+    TResult? Function(DioException error)? notFound,
+    TResult? Function(DioException error, R response)? unprocessableEntity,
+    TResult? Function(DioException error)? serverError,
+    TResult? Function(DioException error)? serviceUnavailable,
+    TResult? Function(
+            String message, bool isConnectionIssue, DioException? error)?
         genericError,
   }) {
     return okNoContent?.call();
@@ -375,13 +383,14 @@ class _$_OkNoContent<R> implements _OkNoContent<R> {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(R response)? ok,
     TResult Function()? okNoContent,
-    TResult Function(DioError error)? unauthorized,
-    TResult Function(DioError error)? forbidden,
-    TResult Function(DioError error)? notFound,
-    TResult Function(DioError error, R response)? unprocessableEntity,
-    TResult Function(DioError error)? serverError,
-    TResult Function(DioError error)? serviceUnavailable,
-    TResult Function(String message, bool isConnectionIssue, DioError? error)?
+    TResult Function(DioException error)? unauthorized,
+    TResult Function(DioException error)? forbidden,
+    TResult Function(DioException error)? notFound,
+    TResult Function(DioException error, R response)? unprocessableEntity,
+    TResult Function(DioException error)? serverError,
+    TResult Function(DioException error)? serviceUnavailable,
+    TResult Function(
+            String message, bool isConnectionIssue, DioException? error)?
         genericError,
     required TResult orElse(),
   }) {
@@ -455,7 +464,7 @@ abstract class _$$_UnauthorizedCopyWith<R, $Res> {
           _$_Unauthorized<R> value, $Res Function(_$_Unauthorized<R>) then) =
       __$$_UnauthorizedCopyWithImpl<R, $Res>;
   @useResult
-  $Res call({DioError error});
+  $Res call({DioException error});
 }
 
 /// @nodoc
@@ -475,7 +484,7 @@ class __$$_UnauthorizedCopyWithImpl<R, $Res>
       null == error
           ? _value.error
           : error // ignore: cast_nullable_to_non_nullable
-              as DioError,
+              as DioException,
     ));
   }
 }
@@ -486,7 +495,7 @@ class _$_Unauthorized<R> implements _Unauthorized<R> {
   const _$_Unauthorized(this.error);
 
   @override
-  final DioError error;
+  final DioException error;
 
   @override
   String toString() {
@@ -515,14 +524,15 @@ class _$_Unauthorized<R> implements _Unauthorized<R> {
   TResult when<TResult extends Object?>({
     required TResult Function(R response) ok,
     required TResult Function() okNoContent,
-    required TResult Function(DioError error) unauthorized,
-    required TResult Function(DioError error) forbidden,
-    required TResult Function(DioError error) notFound,
-    required TResult Function(DioError error, R response) unprocessableEntity,
-    required TResult Function(DioError error) serverError,
-    required TResult Function(DioError error) serviceUnavailable,
+    required TResult Function(DioException error) unauthorized,
+    required TResult Function(DioException error) forbidden,
+    required TResult Function(DioException error) notFound,
+    required TResult Function(DioException error, R response)
+        unprocessableEntity,
+    required TResult Function(DioException error) serverError,
+    required TResult Function(DioException error) serviceUnavailable,
     required TResult Function(
-            String message, bool isConnectionIssue, DioError? error)
+            String message, bool isConnectionIssue, DioException? error)
         genericError,
   }) {
     return unauthorized(error);
@@ -533,13 +543,14 @@ class _$_Unauthorized<R> implements _Unauthorized<R> {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(R response)? ok,
     TResult? Function()? okNoContent,
-    TResult? Function(DioError error)? unauthorized,
-    TResult? Function(DioError error)? forbidden,
-    TResult? Function(DioError error)? notFound,
-    TResult? Function(DioError error, R response)? unprocessableEntity,
-    TResult? Function(DioError error)? serverError,
-    TResult? Function(DioError error)? serviceUnavailable,
-    TResult? Function(String message, bool isConnectionIssue, DioError? error)?
+    TResult? Function(DioException error)? unauthorized,
+    TResult? Function(DioException error)? forbidden,
+    TResult? Function(DioException error)? notFound,
+    TResult? Function(DioException error, R response)? unprocessableEntity,
+    TResult? Function(DioException error)? serverError,
+    TResult? Function(DioException error)? serviceUnavailable,
+    TResult? Function(
+            String message, bool isConnectionIssue, DioException? error)?
         genericError,
   }) {
     return unauthorized?.call(error);
@@ -550,13 +561,14 @@ class _$_Unauthorized<R> implements _Unauthorized<R> {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(R response)? ok,
     TResult Function()? okNoContent,
-    TResult Function(DioError error)? unauthorized,
-    TResult Function(DioError error)? forbidden,
-    TResult Function(DioError error)? notFound,
-    TResult Function(DioError error, R response)? unprocessableEntity,
-    TResult Function(DioError error)? serverError,
-    TResult Function(DioError error)? serviceUnavailable,
-    TResult Function(String message, bool isConnectionIssue, DioError? error)?
+    TResult Function(DioException error)? unauthorized,
+    TResult Function(DioException error)? forbidden,
+    TResult Function(DioException error)? notFound,
+    TResult Function(DioException error, R response)? unprocessableEntity,
+    TResult Function(DioException error)? serverError,
+    TResult Function(DioException error)? serviceUnavailable,
+    TResult Function(
+            String message, bool isConnectionIssue, DioException? error)?
         genericError,
     required TResult orElse(),
   }) {
@@ -621,9 +633,9 @@ class _$_Unauthorized<R> implements _Unauthorized<R> {
 }
 
 abstract class _Unauthorized<R> implements NetworkResponse<R> {
-  const factory _Unauthorized(final DioError error) = _$_Unauthorized<R>;
+  const factory _Unauthorized(final DioException error) = _$_Unauthorized<R>;
 
-  DioError get error;
+  DioException get error;
   @JsonKey(ignore: true)
   _$$_UnauthorizedCopyWith<R, _$_Unauthorized<R>> get copyWith =>
       throw _privateConstructorUsedError;
@@ -635,7 +647,7 @@ abstract class _$$_ForbiddenCopyWith<R, $Res> {
           _$_Forbidden<R> value, $Res Function(_$_Forbidden<R>) then) =
       __$$_ForbiddenCopyWithImpl<R, $Res>;
   @useResult
-  $Res call({DioError error});
+  $Res call({DioException error});
 }
 
 /// @nodoc
@@ -655,7 +667,7 @@ class __$$_ForbiddenCopyWithImpl<R, $Res>
       null == error
           ? _value.error
           : error // ignore: cast_nullable_to_non_nullable
-              as DioError,
+              as DioException,
     ));
   }
 }
@@ -666,7 +678,7 @@ class _$_Forbidden<R> implements _Forbidden<R> {
   const _$_Forbidden(this.error);
 
   @override
-  final DioError error;
+  final DioException error;
 
   @override
   String toString() {
@@ -695,14 +707,15 @@ class _$_Forbidden<R> implements _Forbidden<R> {
   TResult when<TResult extends Object?>({
     required TResult Function(R response) ok,
     required TResult Function() okNoContent,
-    required TResult Function(DioError error) unauthorized,
-    required TResult Function(DioError error) forbidden,
-    required TResult Function(DioError error) notFound,
-    required TResult Function(DioError error, R response) unprocessableEntity,
-    required TResult Function(DioError error) serverError,
-    required TResult Function(DioError error) serviceUnavailable,
+    required TResult Function(DioException error) unauthorized,
+    required TResult Function(DioException error) forbidden,
+    required TResult Function(DioException error) notFound,
+    required TResult Function(DioException error, R response)
+        unprocessableEntity,
+    required TResult Function(DioException error) serverError,
+    required TResult Function(DioException error) serviceUnavailable,
     required TResult Function(
-            String message, bool isConnectionIssue, DioError? error)
+            String message, bool isConnectionIssue, DioException? error)
         genericError,
   }) {
     return forbidden(error);
@@ -713,13 +726,14 @@ class _$_Forbidden<R> implements _Forbidden<R> {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(R response)? ok,
     TResult? Function()? okNoContent,
-    TResult? Function(DioError error)? unauthorized,
-    TResult? Function(DioError error)? forbidden,
-    TResult? Function(DioError error)? notFound,
-    TResult? Function(DioError error, R response)? unprocessableEntity,
-    TResult? Function(DioError error)? serverError,
-    TResult? Function(DioError error)? serviceUnavailable,
-    TResult? Function(String message, bool isConnectionIssue, DioError? error)?
+    TResult? Function(DioException error)? unauthorized,
+    TResult? Function(DioException error)? forbidden,
+    TResult? Function(DioException error)? notFound,
+    TResult? Function(DioException error, R response)? unprocessableEntity,
+    TResult? Function(DioException error)? serverError,
+    TResult? Function(DioException error)? serviceUnavailable,
+    TResult? Function(
+            String message, bool isConnectionIssue, DioException? error)?
         genericError,
   }) {
     return forbidden?.call(error);
@@ -730,13 +744,14 @@ class _$_Forbidden<R> implements _Forbidden<R> {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(R response)? ok,
     TResult Function()? okNoContent,
-    TResult Function(DioError error)? unauthorized,
-    TResult Function(DioError error)? forbidden,
-    TResult Function(DioError error)? notFound,
-    TResult Function(DioError error, R response)? unprocessableEntity,
-    TResult Function(DioError error)? serverError,
-    TResult Function(DioError error)? serviceUnavailable,
-    TResult Function(String message, bool isConnectionIssue, DioError? error)?
+    TResult Function(DioException error)? unauthorized,
+    TResult Function(DioException error)? forbidden,
+    TResult Function(DioException error)? notFound,
+    TResult Function(DioException error, R response)? unprocessableEntity,
+    TResult Function(DioException error)? serverError,
+    TResult Function(DioException error)? serviceUnavailable,
+    TResult Function(
+            String message, bool isConnectionIssue, DioException? error)?
         genericError,
     required TResult orElse(),
   }) {
@@ -801,9 +816,9 @@ class _$_Forbidden<R> implements _Forbidden<R> {
 }
 
 abstract class _Forbidden<R> implements NetworkResponse<R> {
-  const factory _Forbidden(final DioError error) = _$_Forbidden<R>;
+  const factory _Forbidden(final DioException error) = _$_Forbidden<R>;
 
-  DioError get error;
+  DioException get error;
   @JsonKey(ignore: true)
   _$$_ForbiddenCopyWith<R, _$_Forbidden<R>> get copyWith =>
       throw _privateConstructorUsedError;
@@ -815,7 +830,7 @@ abstract class _$$_NotFoundCopyWith<R, $Res> {
           _$_NotFound<R> value, $Res Function(_$_NotFound<R>) then) =
       __$$_NotFoundCopyWithImpl<R, $Res>;
   @useResult
-  $Res call({DioError error});
+  $Res call({DioException error});
 }
 
 /// @nodoc
@@ -835,7 +850,7 @@ class __$$_NotFoundCopyWithImpl<R, $Res>
       null == error
           ? _value.error
           : error // ignore: cast_nullable_to_non_nullable
-              as DioError,
+              as DioException,
     ));
   }
 }
@@ -846,7 +861,7 @@ class _$_NotFound<R> implements _NotFound<R> {
   const _$_NotFound(this.error);
 
   @override
-  final DioError error;
+  final DioException error;
 
   @override
   String toString() {
@@ -875,14 +890,15 @@ class _$_NotFound<R> implements _NotFound<R> {
   TResult when<TResult extends Object?>({
     required TResult Function(R response) ok,
     required TResult Function() okNoContent,
-    required TResult Function(DioError error) unauthorized,
-    required TResult Function(DioError error) forbidden,
-    required TResult Function(DioError error) notFound,
-    required TResult Function(DioError error, R response) unprocessableEntity,
-    required TResult Function(DioError error) serverError,
-    required TResult Function(DioError error) serviceUnavailable,
+    required TResult Function(DioException error) unauthorized,
+    required TResult Function(DioException error) forbidden,
+    required TResult Function(DioException error) notFound,
+    required TResult Function(DioException error, R response)
+        unprocessableEntity,
+    required TResult Function(DioException error) serverError,
+    required TResult Function(DioException error) serviceUnavailable,
     required TResult Function(
-            String message, bool isConnectionIssue, DioError? error)
+            String message, bool isConnectionIssue, DioException? error)
         genericError,
   }) {
     return notFound(error);
@@ -893,13 +909,14 @@ class _$_NotFound<R> implements _NotFound<R> {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(R response)? ok,
     TResult? Function()? okNoContent,
-    TResult? Function(DioError error)? unauthorized,
-    TResult? Function(DioError error)? forbidden,
-    TResult? Function(DioError error)? notFound,
-    TResult? Function(DioError error, R response)? unprocessableEntity,
-    TResult? Function(DioError error)? serverError,
-    TResult? Function(DioError error)? serviceUnavailable,
-    TResult? Function(String message, bool isConnectionIssue, DioError? error)?
+    TResult? Function(DioException error)? unauthorized,
+    TResult? Function(DioException error)? forbidden,
+    TResult? Function(DioException error)? notFound,
+    TResult? Function(DioException error, R response)? unprocessableEntity,
+    TResult? Function(DioException error)? serverError,
+    TResult? Function(DioException error)? serviceUnavailable,
+    TResult? Function(
+            String message, bool isConnectionIssue, DioException? error)?
         genericError,
   }) {
     return notFound?.call(error);
@@ -910,13 +927,14 @@ class _$_NotFound<R> implements _NotFound<R> {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(R response)? ok,
     TResult Function()? okNoContent,
-    TResult Function(DioError error)? unauthorized,
-    TResult Function(DioError error)? forbidden,
-    TResult Function(DioError error)? notFound,
-    TResult Function(DioError error, R response)? unprocessableEntity,
-    TResult Function(DioError error)? serverError,
-    TResult Function(DioError error)? serviceUnavailable,
-    TResult Function(String message, bool isConnectionIssue, DioError? error)?
+    TResult Function(DioException error)? unauthorized,
+    TResult Function(DioException error)? forbidden,
+    TResult Function(DioException error)? notFound,
+    TResult Function(DioException error, R response)? unprocessableEntity,
+    TResult Function(DioException error)? serverError,
+    TResult Function(DioException error)? serviceUnavailable,
+    TResult Function(
+            String message, bool isConnectionIssue, DioException? error)?
         genericError,
     required TResult orElse(),
   }) {
@@ -981,9 +999,9 @@ class _$_NotFound<R> implements _NotFound<R> {
 }
 
 abstract class _NotFound<R> implements NetworkResponse<R> {
-  const factory _NotFound(final DioError error) = _$_NotFound<R>;
+  const factory _NotFound(final DioException error) = _$_NotFound<R>;
 
-  DioError get error;
+  DioException get error;
   @JsonKey(ignore: true)
   _$$_NotFoundCopyWith<R, _$_NotFound<R>> get copyWith =>
       throw _privateConstructorUsedError;
@@ -995,7 +1013,7 @@ abstract class _$$_UnprocessableEntityCopyWith<R, $Res> {
           $Res Function(_$_UnprocessableEntity<R>) then) =
       __$$_UnprocessableEntityCopyWithImpl<R, $Res>;
   @useResult
-  $Res call({DioError error, R response});
+  $Res call({DioException error, R response});
 }
 
 /// @nodoc
@@ -1016,7 +1034,7 @@ class __$$_UnprocessableEntityCopyWithImpl<R, $Res>
       error: null == error
           ? _value.error
           : error // ignore: cast_nullable_to_non_nullable
-              as DioError,
+              as DioException,
       response: freezed == response
           ? _value.response
           : response // ignore: cast_nullable_to_non_nullable
@@ -1031,7 +1049,7 @@ class _$_UnprocessableEntity<R> implements _UnprocessableEntity<R> {
   const _$_UnprocessableEntity({required this.error, required this.response});
 
   @override
-  final DioError error;
+  final DioException error;
   @override
   final R response;
 
@@ -1065,14 +1083,15 @@ class _$_UnprocessableEntity<R> implements _UnprocessableEntity<R> {
   TResult when<TResult extends Object?>({
     required TResult Function(R response) ok,
     required TResult Function() okNoContent,
-    required TResult Function(DioError error) unauthorized,
-    required TResult Function(DioError error) forbidden,
-    required TResult Function(DioError error) notFound,
-    required TResult Function(DioError error, R response) unprocessableEntity,
-    required TResult Function(DioError error) serverError,
-    required TResult Function(DioError error) serviceUnavailable,
+    required TResult Function(DioException error) unauthorized,
+    required TResult Function(DioException error) forbidden,
+    required TResult Function(DioException error) notFound,
+    required TResult Function(DioException error, R response)
+        unprocessableEntity,
+    required TResult Function(DioException error) serverError,
+    required TResult Function(DioException error) serviceUnavailable,
     required TResult Function(
-            String message, bool isConnectionIssue, DioError? error)
+            String message, bool isConnectionIssue, DioException? error)
         genericError,
   }) {
     return unprocessableEntity(error, response);
@@ -1083,13 +1102,14 @@ class _$_UnprocessableEntity<R> implements _UnprocessableEntity<R> {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(R response)? ok,
     TResult? Function()? okNoContent,
-    TResult? Function(DioError error)? unauthorized,
-    TResult? Function(DioError error)? forbidden,
-    TResult? Function(DioError error)? notFound,
-    TResult? Function(DioError error, R response)? unprocessableEntity,
-    TResult? Function(DioError error)? serverError,
-    TResult? Function(DioError error)? serviceUnavailable,
-    TResult? Function(String message, bool isConnectionIssue, DioError? error)?
+    TResult? Function(DioException error)? unauthorized,
+    TResult? Function(DioException error)? forbidden,
+    TResult? Function(DioException error)? notFound,
+    TResult? Function(DioException error, R response)? unprocessableEntity,
+    TResult? Function(DioException error)? serverError,
+    TResult? Function(DioException error)? serviceUnavailable,
+    TResult? Function(
+            String message, bool isConnectionIssue, DioException? error)?
         genericError,
   }) {
     return unprocessableEntity?.call(error, response);
@@ -1100,13 +1120,14 @@ class _$_UnprocessableEntity<R> implements _UnprocessableEntity<R> {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(R response)? ok,
     TResult Function()? okNoContent,
-    TResult Function(DioError error)? unauthorized,
-    TResult Function(DioError error)? forbidden,
-    TResult Function(DioError error)? notFound,
-    TResult Function(DioError error, R response)? unprocessableEntity,
-    TResult Function(DioError error)? serverError,
-    TResult Function(DioError error)? serviceUnavailable,
-    TResult Function(String message, bool isConnectionIssue, DioError? error)?
+    TResult Function(DioException error)? unauthorized,
+    TResult Function(DioException error)? forbidden,
+    TResult Function(DioException error)? notFound,
+    TResult Function(DioException error, R response)? unprocessableEntity,
+    TResult Function(DioException error)? serverError,
+    TResult Function(DioException error)? serviceUnavailable,
+    TResult Function(
+            String message, bool isConnectionIssue, DioException? error)?
         genericError,
     required TResult orElse(),
   }) {
@@ -1172,10 +1193,10 @@ class _$_UnprocessableEntity<R> implements _UnprocessableEntity<R> {
 
 abstract class _UnprocessableEntity<R> implements NetworkResponse<R> {
   const factory _UnprocessableEntity(
-      {required final DioError error,
+      {required final DioException error,
       required final R response}) = _$_UnprocessableEntity<R>;
 
-  DioError get error;
+  DioException get error;
   R get response;
   @JsonKey(ignore: true)
   _$$_UnprocessableEntityCopyWith<R, _$_UnprocessableEntity<R>> get copyWith =>
@@ -1188,7 +1209,7 @@ abstract class _$$_ServerErrorCopyWith<R, $Res> {
           _$_ServerError<R> value, $Res Function(_$_ServerError<R>) then) =
       __$$_ServerErrorCopyWithImpl<R, $Res>;
   @useResult
-  $Res call({DioError error});
+  $Res call({DioException error});
 }
 
 /// @nodoc
@@ -1208,7 +1229,7 @@ class __$$_ServerErrorCopyWithImpl<R, $Res>
       null == error
           ? _value.error
           : error // ignore: cast_nullable_to_non_nullable
-              as DioError,
+              as DioException,
     ));
   }
 }
@@ -1219,7 +1240,7 @@ class _$_ServerError<R> implements _ServerError<R> {
   const _$_ServerError(this.error);
 
   @override
-  final DioError error;
+  final DioException error;
 
   @override
   String toString() {
@@ -1248,14 +1269,15 @@ class _$_ServerError<R> implements _ServerError<R> {
   TResult when<TResult extends Object?>({
     required TResult Function(R response) ok,
     required TResult Function() okNoContent,
-    required TResult Function(DioError error) unauthorized,
-    required TResult Function(DioError error) forbidden,
-    required TResult Function(DioError error) notFound,
-    required TResult Function(DioError error, R response) unprocessableEntity,
-    required TResult Function(DioError error) serverError,
-    required TResult Function(DioError error) serviceUnavailable,
+    required TResult Function(DioException error) unauthorized,
+    required TResult Function(DioException error) forbidden,
+    required TResult Function(DioException error) notFound,
+    required TResult Function(DioException error, R response)
+        unprocessableEntity,
+    required TResult Function(DioException error) serverError,
+    required TResult Function(DioException error) serviceUnavailable,
     required TResult Function(
-            String message, bool isConnectionIssue, DioError? error)
+            String message, bool isConnectionIssue, DioException? error)
         genericError,
   }) {
     return serverError(error);
@@ -1266,13 +1288,14 @@ class _$_ServerError<R> implements _ServerError<R> {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(R response)? ok,
     TResult? Function()? okNoContent,
-    TResult? Function(DioError error)? unauthorized,
-    TResult? Function(DioError error)? forbidden,
-    TResult? Function(DioError error)? notFound,
-    TResult? Function(DioError error, R response)? unprocessableEntity,
-    TResult? Function(DioError error)? serverError,
-    TResult? Function(DioError error)? serviceUnavailable,
-    TResult? Function(String message, bool isConnectionIssue, DioError? error)?
+    TResult? Function(DioException error)? unauthorized,
+    TResult? Function(DioException error)? forbidden,
+    TResult? Function(DioException error)? notFound,
+    TResult? Function(DioException error, R response)? unprocessableEntity,
+    TResult? Function(DioException error)? serverError,
+    TResult? Function(DioException error)? serviceUnavailable,
+    TResult? Function(
+            String message, bool isConnectionIssue, DioException? error)?
         genericError,
   }) {
     return serverError?.call(error);
@@ -1283,13 +1306,14 @@ class _$_ServerError<R> implements _ServerError<R> {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(R response)? ok,
     TResult Function()? okNoContent,
-    TResult Function(DioError error)? unauthorized,
-    TResult Function(DioError error)? forbidden,
-    TResult Function(DioError error)? notFound,
-    TResult Function(DioError error, R response)? unprocessableEntity,
-    TResult Function(DioError error)? serverError,
-    TResult Function(DioError error)? serviceUnavailable,
-    TResult Function(String message, bool isConnectionIssue, DioError? error)?
+    TResult Function(DioException error)? unauthorized,
+    TResult Function(DioException error)? forbidden,
+    TResult Function(DioException error)? notFound,
+    TResult Function(DioException error, R response)? unprocessableEntity,
+    TResult Function(DioException error)? serverError,
+    TResult Function(DioException error)? serviceUnavailable,
+    TResult Function(
+            String message, bool isConnectionIssue, DioException? error)?
         genericError,
     required TResult orElse(),
   }) {
@@ -1354,9 +1378,9 @@ class _$_ServerError<R> implements _ServerError<R> {
 }
 
 abstract class _ServerError<R> implements NetworkResponse<R> {
-  const factory _ServerError(final DioError error) = _$_ServerError<R>;
+  const factory _ServerError(final DioException error) = _$_ServerError<R>;
 
-  DioError get error;
+  DioException get error;
   @JsonKey(ignore: true)
   _$$_ServerErrorCopyWith<R, _$_ServerError<R>> get copyWith =>
       throw _privateConstructorUsedError;
@@ -1368,7 +1392,7 @@ abstract class _$$_ServiceUnavailableCopyWith<R, $Res> {
           $Res Function(_$_ServiceUnavailable<R>) then) =
       __$$_ServiceUnavailableCopyWithImpl<R, $Res>;
   @useResult
-  $Res call({DioError error});
+  $Res call({DioException error});
 }
 
 /// @nodoc
@@ -1388,7 +1412,7 @@ class __$$_ServiceUnavailableCopyWithImpl<R, $Res>
       null == error
           ? _value.error
           : error // ignore: cast_nullable_to_non_nullable
-              as DioError,
+              as DioException,
     ));
   }
 }
@@ -1399,7 +1423,7 @@ class _$_ServiceUnavailable<R> implements _ServiceUnavailable<R> {
   const _$_ServiceUnavailable(this.error);
 
   @override
-  final DioError error;
+  final DioException error;
 
   @override
   String toString() {
@@ -1429,14 +1453,15 @@ class _$_ServiceUnavailable<R> implements _ServiceUnavailable<R> {
   TResult when<TResult extends Object?>({
     required TResult Function(R response) ok,
     required TResult Function() okNoContent,
-    required TResult Function(DioError error) unauthorized,
-    required TResult Function(DioError error) forbidden,
-    required TResult Function(DioError error) notFound,
-    required TResult Function(DioError error, R response) unprocessableEntity,
-    required TResult Function(DioError error) serverError,
-    required TResult Function(DioError error) serviceUnavailable,
+    required TResult Function(DioException error) unauthorized,
+    required TResult Function(DioException error) forbidden,
+    required TResult Function(DioException error) notFound,
+    required TResult Function(DioException error, R response)
+        unprocessableEntity,
+    required TResult Function(DioException error) serverError,
+    required TResult Function(DioException error) serviceUnavailable,
     required TResult Function(
-            String message, bool isConnectionIssue, DioError? error)
+            String message, bool isConnectionIssue, DioException? error)
         genericError,
   }) {
     return serviceUnavailable(error);
@@ -1447,13 +1472,14 @@ class _$_ServiceUnavailable<R> implements _ServiceUnavailable<R> {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(R response)? ok,
     TResult? Function()? okNoContent,
-    TResult? Function(DioError error)? unauthorized,
-    TResult? Function(DioError error)? forbidden,
-    TResult? Function(DioError error)? notFound,
-    TResult? Function(DioError error, R response)? unprocessableEntity,
-    TResult? Function(DioError error)? serverError,
-    TResult? Function(DioError error)? serviceUnavailable,
-    TResult? Function(String message, bool isConnectionIssue, DioError? error)?
+    TResult? Function(DioException error)? unauthorized,
+    TResult? Function(DioException error)? forbidden,
+    TResult? Function(DioException error)? notFound,
+    TResult? Function(DioException error, R response)? unprocessableEntity,
+    TResult? Function(DioException error)? serverError,
+    TResult? Function(DioException error)? serviceUnavailable,
+    TResult? Function(
+            String message, bool isConnectionIssue, DioException? error)?
         genericError,
   }) {
     return serviceUnavailable?.call(error);
@@ -1464,13 +1490,14 @@ class _$_ServiceUnavailable<R> implements _ServiceUnavailable<R> {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(R response)? ok,
     TResult Function()? okNoContent,
-    TResult Function(DioError error)? unauthorized,
-    TResult Function(DioError error)? forbidden,
-    TResult Function(DioError error)? notFound,
-    TResult Function(DioError error, R response)? unprocessableEntity,
-    TResult Function(DioError error)? serverError,
-    TResult Function(DioError error)? serviceUnavailable,
-    TResult Function(String message, bool isConnectionIssue, DioError? error)?
+    TResult Function(DioException error)? unauthorized,
+    TResult Function(DioException error)? forbidden,
+    TResult Function(DioException error)? notFound,
+    TResult Function(DioException error, R response)? unprocessableEntity,
+    TResult Function(DioException error)? serverError,
+    TResult Function(DioException error)? serviceUnavailable,
+    TResult Function(
+            String message, bool isConnectionIssue, DioException? error)?
         genericError,
     required TResult orElse(),
   }) {
@@ -1535,10 +1562,10 @@ class _$_ServiceUnavailable<R> implements _ServiceUnavailable<R> {
 }
 
 abstract class _ServiceUnavailable<R> implements NetworkResponse<R> {
-  const factory _ServiceUnavailable(final DioError error) =
+  const factory _ServiceUnavailable(final DioException error) =
       _$_ServiceUnavailable<R>;
 
-  DioError get error;
+  DioException get error;
   @JsonKey(ignore: true)
   _$$_ServiceUnavailableCopyWith<R, _$_ServiceUnavailable<R>> get copyWith =>
       throw _privateConstructorUsedError;
@@ -1550,7 +1577,7 @@ abstract class _$$_GenericErrorCopyWith<R, $Res> {
           _$_GenericError<R> value, $Res Function(_$_GenericError<R>) then) =
       __$$_GenericErrorCopyWithImpl<R, $Res>;
   @useResult
-  $Res call({String message, bool isConnectionIssue, DioError? error});
+  $Res call({String message, bool isConnectionIssue, DioException? error});
 }
 
 /// @nodoc
@@ -1580,7 +1607,7 @@ class __$$_GenericErrorCopyWithImpl<R, $Res>
       error: freezed == error
           ? _value.error
           : error // ignore: cast_nullable_to_non_nullable
-              as DioError?,
+              as DioException?,
     ));
   }
 }
@@ -1596,7 +1623,7 @@ class _$_GenericError<R> implements _GenericError<R> {
   @override
   final bool isConnectionIssue;
   @override
-  final DioError? error;
+  final DioException? error;
 
   @override
   String toString() {
@@ -1629,14 +1656,15 @@ class _$_GenericError<R> implements _GenericError<R> {
   TResult when<TResult extends Object?>({
     required TResult Function(R response) ok,
     required TResult Function() okNoContent,
-    required TResult Function(DioError error) unauthorized,
-    required TResult Function(DioError error) forbidden,
-    required TResult Function(DioError error) notFound,
-    required TResult Function(DioError error, R response) unprocessableEntity,
-    required TResult Function(DioError error) serverError,
-    required TResult Function(DioError error) serviceUnavailable,
+    required TResult Function(DioException error) unauthorized,
+    required TResult Function(DioException error) forbidden,
+    required TResult Function(DioException error) notFound,
+    required TResult Function(DioException error, R response)
+        unprocessableEntity,
+    required TResult Function(DioException error) serverError,
+    required TResult Function(DioException error) serviceUnavailable,
     required TResult Function(
-            String message, bool isConnectionIssue, DioError? error)
+            String message, bool isConnectionIssue, DioException? error)
         genericError,
   }) {
     return genericError(message, isConnectionIssue, error);
@@ -1647,13 +1675,14 @@ class _$_GenericError<R> implements _GenericError<R> {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(R response)? ok,
     TResult? Function()? okNoContent,
-    TResult? Function(DioError error)? unauthorized,
-    TResult? Function(DioError error)? forbidden,
-    TResult? Function(DioError error)? notFound,
-    TResult? Function(DioError error, R response)? unprocessableEntity,
-    TResult? Function(DioError error)? serverError,
-    TResult? Function(DioError error)? serviceUnavailable,
-    TResult? Function(String message, bool isConnectionIssue, DioError? error)?
+    TResult? Function(DioException error)? unauthorized,
+    TResult? Function(DioException error)? forbidden,
+    TResult? Function(DioException error)? notFound,
+    TResult? Function(DioException error, R response)? unprocessableEntity,
+    TResult? Function(DioException error)? serverError,
+    TResult? Function(DioException error)? serviceUnavailable,
+    TResult? Function(
+            String message, bool isConnectionIssue, DioException? error)?
         genericError,
   }) {
     return genericError?.call(message, isConnectionIssue, error);
@@ -1664,13 +1693,14 @@ class _$_GenericError<R> implements _GenericError<R> {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(R response)? ok,
     TResult Function()? okNoContent,
-    TResult Function(DioError error)? unauthorized,
-    TResult Function(DioError error)? forbidden,
-    TResult Function(DioError error)? notFound,
-    TResult Function(DioError error, R response)? unprocessableEntity,
-    TResult Function(DioError error)? serverError,
-    TResult Function(DioError error)? serviceUnavailable,
-    TResult Function(String message, bool isConnectionIssue, DioError? error)?
+    TResult Function(DioException error)? unauthorized,
+    TResult Function(DioException error)? forbidden,
+    TResult Function(DioException error)? notFound,
+    TResult Function(DioException error, R response)? unprocessableEntity,
+    TResult Function(DioException error)? serverError,
+    TResult Function(DioException error)? serviceUnavailable,
+    TResult Function(
+            String message, bool isConnectionIssue, DioException? error)?
         genericError,
     required TResult orElse(),
   }) {
@@ -1738,11 +1768,11 @@ abstract class _GenericError<R> implements NetworkResponse<R> {
   const factory _GenericError(
       {required final String message,
       required final bool isConnectionIssue,
-      final DioError? error}) = _$_GenericError<R>;
+      final DioException? error}) = _$_GenericError<R>;
 
   String get message;
   bool get isConnectionIssue;
-  DioError? get error;
+  DioException? get error;
   @JsonKey(ignore: true)
   _$$_GenericErrorCopyWith<R, _$_GenericError<R>> get copyWith =>
       throw _privateConstructorUsedError;

--- a/lib/src/sturdy_http.dart
+++ b/lib/src/sturdy_http.dart
@@ -3,7 +3,6 @@ import 'dart:isolate';
 
 import 'package:collection/collection.dart';
 import 'package:dio/dio.dart';
-import 'package:dio/io.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:sturdy_http/sturdy_http.dart';
 import 'package:uuid/uuid.dart';
@@ -164,7 +163,7 @@ class SturdyHttp {
           resolvedResponse = NetworkResponse.ok(data as R);
         }
       }
-    } on DioError catch (error) {
+    } on DioException catch (error) {
       switch (error.response?.statusCode) {
         case 401:
           await _onEvent(SturdyHttpEvent.authFailure(error.requestOptions));
@@ -240,22 +239,6 @@ Dio _configureDio({
     ..map((dio) {
       if (customAdapter != null) {
         return dio..httpClientAdapter = customAdapter;
-      }
-      return dio;
-    })
-    ..map((dio) {
-      if (proxy != null && dio.httpClientAdapter is IOHttpClientAdapter) {
-        final host = proxy['host'];
-        final port = proxy['port'];
-        final proxyString = '$host:$port';
-
-        (dio.httpClientAdapter as IOHttpClientAdapter).onHttpClientCreate =
-            (client) {
-          client.findProxy = (url) {
-            return 'PROXY $proxyString';
-          };
-          return null;
-        };
       }
       return dio;
     });

--- a/lib/src/sturdy_http.dart
+++ b/lib/src/sturdy_http.dart
@@ -134,10 +134,12 @@ class SturdyHttp {
           json: (json) => json,
         ),
         queryParameters: request.queryParams,
-        options: Options(
-          method: request.type.name,
-          headers: request.headers,
-        ),
+        options: request.options != null
+            ? request.options!.copyWith(method: request.type.name)
+            : Options(method: request.type.name),
+        cancelToken: request.cancelToken,
+        onReceiveProgress: request.onReceiveProgress,
+        onSendProgress: request.onSendProgress,
       );
       if (dioResponse.statusCode == 204) {
         resolvedResponse = const NetworkResponse.okNoContent();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sturdy_http
-description: A strongly typed, event-based, reliable HTTP client that wraps `Dio.
+description: A strongly typed, event-based, reliable HTTP client that wraps `Dio`.
 version: 0.1.0
 homepage: https://github.com/Betterment/sturdy_http
 repository: https://github.com/Betterment/sturdy_http

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sturdy_http
 description: A strongly typed, event-based, reliable HTTP client that wraps `Dio.
-version: 0.0.2
+version: 0.0.3
 homepage: https://github.com/Betterment/sturdy_http
 repository: https://github.com/Betterment/sturdy_http
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sturdy_http
 description: A strongly typed, event-based, reliable HTTP client that wraps `Dio.
-version: 0.0.3
+version: 0.1.0
 homepage: https://github.com/Betterment/sturdy_http
 repository: https://github.com/Betterment/sturdy_http
 

--- a/test/src/sturdy_http_test.dart
+++ b/test/src/sturdy_http_test.dart
@@ -147,6 +147,31 @@ void main() {
               );
             });
           });
+
+          group('when manual options are provided', () {
+            test('request options contain manually provided values', () async {
+              await buildSubject().execute<Json, Foo?>(
+                GetRequest(
+                  '/foo',
+                  data: NetworkRequestBody.json(
+                    <String, dynamic>{
+                      'foo': 'bar',
+                    },
+                  ),
+                  options: Options(extra: {'foo': 'bar'}),
+                ),
+                onResponse: (response) {
+                  return response.maybeWhen(orElse: () => null);
+                },
+              );
+              expect(
+                options.extra,
+                isA<Json>()
+                    .having((json) => json.keys.single, 'key', 'foo')
+                    .having((json) => json.values.single, 'value', 'bar'),
+              );
+            });
+          });
         });
 
         group('queryParameters', () {


### PR DESCRIPTION
### 📰 Summary of changes
<!-- Feel free to delete this section if it doesn't apply -->
> What is the new functionality added in this PR?

This PR:

- adds `cancelToken`, `onReceiveProgress` and `onSendProgress` parameters to `NetworkRequest` constructors.
- removes `headers` in favor of using `Dio` `Options` which allow for passing more than just headers. **This is a breaking change.**  
- we also migrate to `DioException` to address deprecation of `DioError`, and remove the proxy configuration on the underlying `Dio` instance during construction of `SturdyHttp`. **These are breaking changes**.

### 🧪 Testing done
<!-- Feel free to delete this section if it doesn't apply -->
> What testing was added to cover the functionality added in this PR

Unit tests are sufficient for this (added one to capture manually provided headers)
