### PR TITLE
feat: add ability to execute raw (untyped) requests

### DIFF
--- a/lib/src/network_request.dart
+++ b/lib/src/network_request.dart
@@ -170,7 +170,7 @@ class RawRequest extends NetworkRequest {
 }
 
 /// The body of a [NetworkRequest].
-@freezed
+@Freezed(copyWith: false)
 class NetworkRequestBody with _$NetworkRequestBody {
   /// An empty body. Results in `null` being passed to `data` of the request.
   const factory NetworkRequestBody.empty() = _Empty;

--- a/lib/src/network_request.dart
+++ b/lib/src/network_request.dart
@@ -156,7 +156,7 @@ class RawRequest extends NetworkRequest {
   const RawRequest(
     String path, {
     required super.type,
-    super.data = const NetworkRequestBody.raw(null),
+    super.data = const NetworkRequestBody.empty(),
     Map<String, dynamic>? queryParameters,
     super.shouldTriggerDataMutation = true,
     super.options,

--- a/lib/src/network_request.dart
+++ b/lib/src/network_request.dart
@@ -146,6 +146,29 @@ class DeleteRequest extends NetworkRequest {
         );
 }
 
+/// {@template raw_request}
+/// A [NetworkRequest] that allows for passing a [NetworkRequestType] (useful
+/// for when this can't be known until runtime). It also defaults to a raw
+/// (null) body.
+/// {@endtemplate}
+class RawRequest extends NetworkRequest {
+  /// {@macro raw_request}
+  const RawRequest(
+    String path, {
+    required super.type,
+    super.data = const NetworkRequestBody.raw(null),
+    Map<String, dynamic>? queryParameters,
+    super.shouldTriggerDataMutation = true,
+    super.options,
+    super.cancelToken,
+    super.onReceiveProgress,
+    super.onSendProgress,
+  }) : super(
+          path: path,
+          queryParams: queryParameters,
+        );
+}
+
 /// The body of a [NetworkRequest].
 @freezed
 class NetworkRequestBody with _$NetworkRequestBody {
@@ -154,4 +177,9 @@ class NetworkRequestBody with _$NetworkRequestBody {
 
   /// A JSON body. Passed directly to `data` of the request.
   const factory NetworkRequestBody.json(Json data) = _Json;
+
+  /// A raw body. Allows for nullable untyped data that is passed directly
+  /// to `data` of the request, useful for instances where the data type
+  /// is not known until runtime.
+  const factory NetworkRequestBody.raw(Object? data) = _Raw;
 }

--- a/lib/src/network_request.freezed.dart
+++ b/lib/src/network_request.freezed.dart
@@ -63,38 +63,6 @@ mixin _$NetworkRequestBody {
 }
 
 /// @nodoc
-abstract class $NetworkRequestBodyCopyWith<$Res> {
-  factory $NetworkRequestBodyCopyWith(
-          NetworkRequestBody value, $Res Function(NetworkRequestBody) then) =
-      _$NetworkRequestBodyCopyWithImpl<$Res, NetworkRequestBody>;
-}
-
-/// @nodoc
-class _$NetworkRequestBodyCopyWithImpl<$Res, $Val extends NetworkRequestBody>
-    implements $NetworkRequestBodyCopyWith<$Res> {
-  _$NetworkRequestBodyCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-}
-
-/// @nodoc
-abstract class _$$_EmptyCopyWith<$Res> {
-  factory _$$_EmptyCopyWith(_$_Empty value, $Res Function(_$_Empty) then) =
-      __$$_EmptyCopyWithImpl<$Res>;
-}
-
-/// @nodoc
-class __$$_EmptyCopyWithImpl<$Res>
-    extends _$NetworkRequestBodyCopyWithImpl<$Res, _$_Empty>
-    implements _$$_EmptyCopyWith<$Res> {
-  __$$_EmptyCopyWithImpl(_$_Empty _value, $Res Function(_$_Empty) _then)
-      : super(_value, _then);
-}
-
-/// @nodoc
 
 class _$_Empty implements _Empty {
   const _$_Empty();
@@ -187,35 +155,6 @@ abstract class _Empty implements NetworkRequestBody {
 }
 
 /// @nodoc
-abstract class _$$_JsonCopyWith<$Res> {
-  factory _$$_JsonCopyWith(_$_Json value, $Res Function(_$_Json) then) =
-      __$$_JsonCopyWithImpl<$Res>;
-  @useResult
-  $Res call({Map<String, dynamic> data});
-}
-
-/// @nodoc
-class __$$_JsonCopyWithImpl<$Res>
-    extends _$NetworkRequestBodyCopyWithImpl<$Res, _$_Json>
-    implements _$$_JsonCopyWith<$Res> {
-  __$$_JsonCopyWithImpl(_$_Json _value, $Res Function(_$_Json) _then)
-      : super(_value, _then);
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? data = null,
-  }) {
-    return _then(_$_Json(
-      null == data
-          ? _value._data
-          : data // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>,
-    ));
-  }
-}
-
-/// @nodoc
 
 class _$_Json implements _Json {
   const _$_Json(final Map<String, dynamic> data) : _data = data;
@@ -244,12 +183,6 @@ class _$_Json implements _Json {
   @override
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(_data));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$_JsonCopyWith<_$_Json> get copyWith =>
-      __$$_JsonCopyWithImpl<_$_Json>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -324,34 +257,6 @@ abstract class _Json implements NetworkRequestBody {
   const factory _Json(final Map<String, dynamic> data) = _$_Json;
 
   Map<String, dynamic> get data;
-  @JsonKey(ignore: true)
-  _$$_JsonCopyWith<_$_Json> get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class _$$_RawCopyWith<$Res> {
-  factory _$$_RawCopyWith(_$_Raw value, $Res Function(_$_Raw) then) =
-      __$$_RawCopyWithImpl<$Res>;
-  @useResult
-  $Res call({Object? data});
-}
-
-/// @nodoc
-class __$$_RawCopyWithImpl<$Res>
-    extends _$NetworkRequestBodyCopyWithImpl<$Res, _$_Raw>
-    implements _$$_RawCopyWith<$Res> {
-  __$$_RawCopyWithImpl(_$_Raw _value, $Res Function(_$_Raw) _then)
-      : super(_value, _then);
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? data = freezed,
-  }) {
-    return _then(_$_Raw(
-      freezed == data ? _value.data : data,
-    ));
-  }
 }
 
 /// @nodoc
@@ -378,12 +283,6 @@ class _$_Raw implements _Raw {
   @override
   int get hashCode =>
       Object.hash(runtimeType, const DeepCollectionEquality().hash(data));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$_RawCopyWith<_$_Raw> get copyWith =>
-      __$$_RawCopyWithImpl<_$_Raw>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -458,6 +357,4 @@ abstract class _Raw implements NetworkRequestBody {
   const factory _Raw(final Object? data) = _$_Raw;
 
   Object? get data;
-  @JsonKey(ignore: true)
-  _$$_RawCopyWith<_$_Raw> get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/network_request.freezed.dart
+++ b/lib/src/network_request.freezed.dart
@@ -20,18 +20,21 @@ mixin _$NetworkRequestBody {
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
     required TResult Function(Map<String, dynamic> data) json,
+    required TResult Function(Object? data) raw,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? empty,
     TResult? Function(Map<String, dynamic> data)? json,
+    TResult? Function(Object? data)? raw,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? empty,
     TResult Function(Map<String, dynamic> data)? json,
+    TResult Function(Object? data)? raw,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -39,18 +42,21 @@ mixin _$NetworkRequestBody {
   TResult map<TResult extends Object?>({
     required TResult Function(_Empty value) empty,
     required TResult Function(_Json value) json,
+    required TResult Function(_Raw value) raw,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(_Empty value)? empty,
     TResult? Function(_Json value)? json,
+    TResult? Function(_Raw value)? raw,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
     TResult Function(_Empty value)? empty,
     TResult Function(_Json value)? json,
+    TResult Function(_Raw value)? raw,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -112,6 +118,7 @@ class _$_Empty implements _Empty {
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
     required TResult Function(Map<String, dynamic> data) json,
+    required TResult Function(Object? data) raw,
   }) {
     return empty();
   }
@@ -121,6 +128,7 @@ class _$_Empty implements _Empty {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? empty,
     TResult? Function(Map<String, dynamic> data)? json,
+    TResult? Function(Object? data)? raw,
   }) {
     return empty?.call();
   }
@@ -130,6 +138,7 @@ class _$_Empty implements _Empty {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? empty,
     TResult Function(Map<String, dynamic> data)? json,
+    TResult Function(Object? data)? raw,
     required TResult orElse(),
   }) {
     if (empty != null) {
@@ -143,6 +152,7 @@ class _$_Empty implements _Empty {
   TResult map<TResult extends Object?>({
     required TResult Function(_Empty value) empty,
     required TResult Function(_Json value) json,
+    required TResult Function(_Raw value) raw,
   }) {
     return empty(this);
   }
@@ -152,6 +162,7 @@ class _$_Empty implements _Empty {
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(_Empty value)? empty,
     TResult? Function(_Json value)? json,
+    TResult? Function(_Raw value)? raw,
   }) {
     return empty?.call(this);
   }
@@ -161,6 +172,7 @@ class _$_Empty implements _Empty {
   TResult maybeMap<TResult extends Object?>({
     TResult Function(_Empty value)? empty,
     TResult Function(_Json value)? json,
+    TResult Function(_Raw value)? raw,
     required TResult orElse(),
   }) {
     if (empty != null) {
@@ -244,6 +256,7 @@ class _$_Json implements _Json {
   TResult when<TResult extends Object?>({
     required TResult Function() empty,
     required TResult Function(Map<String, dynamic> data) json,
+    required TResult Function(Object? data) raw,
   }) {
     return json(data);
   }
@@ -253,6 +266,7 @@ class _$_Json implements _Json {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? empty,
     TResult? Function(Map<String, dynamic> data)? json,
+    TResult? Function(Object? data)? raw,
   }) {
     return json?.call(data);
   }
@@ -262,6 +276,7 @@ class _$_Json implements _Json {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? empty,
     TResult Function(Map<String, dynamic> data)? json,
+    TResult Function(Object? data)? raw,
     required TResult orElse(),
   }) {
     if (json != null) {
@@ -275,6 +290,7 @@ class _$_Json implements _Json {
   TResult map<TResult extends Object?>({
     required TResult Function(_Empty value) empty,
     required TResult Function(_Json value) json,
+    required TResult Function(_Raw value) raw,
   }) {
     return json(this);
   }
@@ -284,6 +300,7 @@ class _$_Json implements _Json {
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(_Empty value)? empty,
     TResult? Function(_Json value)? json,
+    TResult? Function(_Raw value)? raw,
   }) {
     return json?.call(this);
   }
@@ -293,6 +310,7 @@ class _$_Json implements _Json {
   TResult maybeMap<TResult extends Object?>({
     TResult Function(_Empty value)? empty,
     TResult Function(_Json value)? json,
+    TResult Function(_Raw value)? raw,
     required TResult orElse(),
   }) {
     if (json != null) {
@@ -308,4 +326,138 @@ abstract class _Json implements NetworkRequestBody {
   Map<String, dynamic> get data;
   @JsonKey(ignore: true)
   _$$_JsonCopyWith<_$_Json> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$_RawCopyWith<$Res> {
+  factory _$$_RawCopyWith(_$_Raw value, $Res Function(_$_Raw) then) =
+      __$$_RawCopyWithImpl<$Res>;
+  @useResult
+  $Res call({Object? data});
+}
+
+/// @nodoc
+class __$$_RawCopyWithImpl<$Res>
+    extends _$NetworkRequestBodyCopyWithImpl<$Res, _$_Raw>
+    implements _$$_RawCopyWith<$Res> {
+  __$$_RawCopyWithImpl(_$_Raw _value, $Res Function(_$_Raw) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? data = freezed,
+  }) {
+    return _then(_$_Raw(
+      freezed == data ? _value.data : data,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_Raw implements _Raw {
+  const _$_Raw(this.data);
+
+  @override
+  final Object? data;
+
+  @override
+  String toString() {
+    return 'NetworkRequestBody.raw(data: $data)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_Raw &&
+            const DeepCollectionEquality().equals(other.data, data));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(data));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_RawCopyWith<_$_Raw> get copyWith =>
+      __$$_RawCopyWithImpl<_$_Raw>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() empty,
+    required TResult Function(Map<String, dynamic> data) json,
+    required TResult Function(Object? data) raw,
+  }) {
+    return raw(data);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? empty,
+    TResult? Function(Map<String, dynamic> data)? json,
+    TResult? Function(Object? data)? raw,
+  }) {
+    return raw?.call(data);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? empty,
+    TResult Function(Map<String, dynamic> data)? json,
+    TResult Function(Object? data)? raw,
+    required TResult orElse(),
+  }) {
+    if (raw != null) {
+      return raw(data);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Empty value) empty,
+    required TResult Function(_Json value) json,
+    required TResult Function(_Raw value) raw,
+  }) {
+    return raw(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Empty value)? empty,
+    TResult? Function(_Json value)? json,
+    TResult? Function(_Raw value)? raw,
+  }) {
+    return raw?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Empty value)? empty,
+    TResult Function(_Json value)? json,
+    TResult Function(_Raw value)? raw,
+    required TResult orElse(),
+  }) {
+    if (raw != null) {
+      return raw(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Raw implements NetworkRequestBody {
+  const factory _Raw(final Object? data) = _$_Raw;
+
+  Object? get data;
+  @JsonKey(ignore: true)
+  _$$_RawCopyWith<_$_Raw> get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/sturdy_http.dart
+++ b/lib/src/sturdy_http.dart
@@ -30,8 +30,7 @@ class SturdyHttp {
   final SturdyHttpEventListener? _eventListener;
 
   /// The interceptors provided when this [SturdyHttp] was constructed.
-  UnmodifiableListView<Interceptor> get interceptors =>
-      UnmodifiableListView<Interceptor>(_dio.interceptors);
+  UnmodifiableListView<Interceptor> get interceptors => UnmodifiableListView<Interceptor>(_dio.interceptors);
 
   /// The base URL of the underlying [Dio] instance.
   String get baseUrl => _dio.options.baseUrl;
@@ -117,8 +116,7 @@ class SturdyHttp {
     }
   }
 
-  Future<_ResponsePayload<R>> _handleRequest<R, M>(
-      NetworkRequest request) async {
+  Future<_ResponsePayload<R>> _handleRequest<R, M>(NetworkRequest request) async {
     late final NetworkResponse<R> resolvedResponse;
     Response<Object?>? dioResponse;
     try {
@@ -131,6 +129,7 @@ class SturdyHttp {
         data: request.data.when(
           empty: () => null,
           json: (json) => json,
+          raw: (data) => data,
         ),
         queryParameters: request.queryParams,
         options: request.options != null
@@ -189,16 +188,14 @@ class SturdyHttp {
           break;
         default:
           resolvedResponse = NetworkResponse.genericError(
-            message:
-                'Unexpected status code ${error.response?.statusCode} returned for ${request.path}',
+            message: 'Unexpected status code ${error.response?.statusCode} returned for ${request.path}',
             isConnectionIssue: error.isConnectionIssue(),
             error: error,
           );
       }
     }
     if (resolvedResponse.isSuccess && request.shouldTriggerDataMutation) {
-      await _onEvent(
-          SturdyHttpEvent.mutativeRequestSuccess(dioResponse!.requestOptions));
+      await _onEvent(SturdyHttpEvent.mutativeRequestSuccess(dioResponse!.requestOptions));
     }
     return _ResponsePayload<R>(
       request: request,
@@ -229,9 +226,7 @@ Dio _configureDio({
 }) {
   return Dio()
     // Instruct Dio to use the same Isolate approach as requested of SturdyHttp
-    ..transformer = deserializer is MainIsolateDeserializer
-        ? SyncTransformer()
-        : BackgroundTransformer()
+    ..transformer = deserializer is MainIsolateDeserializer ? SyncTransformer() : BackgroundTransformer()
     ..options.baseUrl = baseUrl
     ..options.listFormat = ListFormat.multiCompatible
     ..interceptors.addAll(interceptors)

--- a/lib/src/sturdy_http.dart
+++ b/lib/src/sturdy_http.dart
@@ -30,7 +30,8 @@ class SturdyHttp {
   final SturdyHttpEventListener? _eventListener;
 
   /// The interceptors provided when this [SturdyHttp] was constructed.
-  UnmodifiableListView<Interceptor> get interceptors => UnmodifiableListView<Interceptor>(_dio.interceptors);
+  UnmodifiableListView<Interceptor> get interceptors =>
+      UnmodifiableListView<Interceptor>(_dio.interceptors);
 
   /// The base URL of the underlying [Dio] instance.
   String get baseUrl => _dio.options.baseUrl;
@@ -116,7 +117,8 @@ class SturdyHttp {
     }
   }
 
-  Future<_ResponsePayload<R>> _handleRequest<R, M>(NetworkRequest request) async {
+  Future<_ResponsePayload<R>> _handleRequest<R, M>(
+      NetworkRequest request) async {
     late final NetworkResponse<R> resolvedResponse;
     Response<Object?>? dioResponse;
     try {
@@ -188,14 +190,16 @@ class SturdyHttp {
           break;
         default:
           resolvedResponse = NetworkResponse.genericError(
-            message: 'Unexpected status code ${error.response?.statusCode} returned for ${request.path}',
+            message:
+                'Unexpected status code ${error.response?.statusCode} returned for ${request.path}',
             isConnectionIssue: error.isConnectionIssue(),
             error: error,
           );
       }
     }
     if (resolvedResponse.isSuccess && request.shouldTriggerDataMutation) {
-      await _onEvent(SturdyHttpEvent.mutativeRequestSuccess(dioResponse!.requestOptions));
+      await _onEvent(
+          SturdyHttpEvent.mutativeRequestSuccess(dioResponse!.requestOptions));
     }
     return _ResponsePayload<R>(
       request: request,
@@ -226,7 +230,9 @@ Dio _configureDio({
 }) {
   return Dio()
     // Instruct Dio to use the same Isolate approach as requested of SturdyHttp
-    ..transformer = deserializer is MainIsolateDeserializer ? SyncTransformer() : BackgroundTransformer()
+    ..transformer = deserializer is MainIsolateDeserializer
+        ? SyncTransformer()
+        : BackgroundTransformer()
     ..options.baseUrl = baseUrl
     ..options.listFormat = ListFormat.multiCompatible
     ..interceptors.addAll(interceptors)


### PR DESCRIPTION
### 📰 Summary of changes
<!-- Feel free to delete this section if it doesn't apply -->
> What is the new functionality added in this PR?

This PR adds `RawRequest` as a subclass of `NetworkRequest` which is a convenience for creating requests whose methods are not known until runtime. This is the case for `RetryInterceptor` in the `test_track_dart_client` (see PR [here](https://github.com/Betterment/test_track_dart_client/pull/38)). Rather than switching on the method of the failed request and creating a request-per-type (where all params other than the `method` are identical), `RawRequest` allows us to pass the type in as a parameter. Very open to other implementations!

### 🧪 Testing done
<!-- Feel free to delete this section if it doesn't apply -->
> What testing was added to cover the functionality added in this PR

Since the underlying data passed to the request type is pre-existing, I didn't add any tests and I think the existing `SturdyHttp` tests are sufficient.