### PR TITLE
refactor: add inferContentType parameter to SturdyHttp constructor

### DIFF
--- a/lib/src/network_request.dart
+++ b/lib/src/network_request.dart
@@ -169,17 +169,25 @@ class RawRequest extends NetworkRequest {
         );
 }
 
-/// The body of a [NetworkRequest].
+/// The body of a [NetworkRequest]. Note that this type is aimed at providing
+/// readability and type safety and does not dictate behavior of [SturdyHttp]
+/// with regards to the content-type header. If you want [SturdyHttp] to infer
+/// the content-type header, configure this via the `inferContentType` parameter
+/// when constructing the instance.
 @Freezed(copyWith: false)
 class NetworkRequestBody with _$NetworkRequestBody {
   /// An empty body. Results in `null` being passed to `data` of the request.
   const factory NetworkRequestBody.empty() = _Empty;
 
-  /// A JSON body. Passed directly to `data` of the request.
+  /// A JSON body. Passed directly to `data` of the request. If `inferContentType`
+  /// has been provided as `true` to the [SturdyHttp] instance, will result in
+  /// an `application-json` `content-type`.
   const factory NetworkRequestBody.json(Json data) = _Json;
 
   /// A raw body. Allows for nullable untyped data that is passed directly
   /// to `data` of the request, useful for instances where the data type
-  /// is not known until runtime.
+  /// is not known until runtime. If `inferContentType` has been provided as
+  /// `true` to the [SturdyHttp] instance *and* the [data] can be used to infer
+  /// the `content-type` header, it will be inferred.
   const factory NetworkRequestBody.raw(Object? data) = _Raw;
 }

--- a/lib/src/sturdy_http.dart
+++ b/lib/src/sturdy_http.dart
@@ -30,7 +30,8 @@ class SturdyHttp {
   final SturdyHttpEventListener? _eventListener;
 
   /// The interceptors provided when this [SturdyHttp] was constructed.
-  UnmodifiableListView<Interceptor> get interceptors => UnmodifiableListView<Interceptor>(_dio.interceptors);
+  UnmodifiableListView<Interceptor> get interceptors =>
+      UnmodifiableListView<Interceptor>(_dio.interceptors);
 
   /// The base URL of the underlying [Dio] instance.
   String get baseUrl => _dio.options.baseUrl;
@@ -118,7 +119,8 @@ class SturdyHttp {
     }
   }
 
-  Future<_ResponsePayload<R>> _handleRequest<R, M>(NetworkRequest request) async {
+  Future<_ResponsePayload<R>> _handleRequest<R, M>(
+      NetworkRequest request) async {
     late final NetworkResponse<R> resolvedResponse;
     Response<Object?>? dioResponse;
     try {
@@ -190,14 +192,16 @@ class SturdyHttp {
           break;
         default:
           resolvedResponse = NetworkResponse.genericError(
-            message: 'Unexpected status code ${error.response?.statusCode} returned for ${request.path}',
+            message:
+                'Unexpected status code ${error.response?.statusCode} returned for ${request.path}',
             isConnectionIssue: error.isConnectionIssue(),
             error: error,
           );
       }
     }
     if (resolvedResponse.isSuccess && request.shouldTriggerDataMutation) {
-      await _onEvent(SturdyHttpEvent.mutativeRequestSuccess(dioResponse!.requestOptions));
+      await _onEvent(
+          SturdyHttpEvent.mutativeRequestSuccess(dioResponse!.requestOptions));
     }
     return _ResponsePayload<R>(
       request: request,
@@ -229,7 +233,9 @@ Dio _configureDio({
 }) {
   return Dio()
     // Instruct Dio to use the same Isolate approach as requested of SturdyHttp
-    ..transformer = deserializer is MainIsolateDeserializer ? SyncTransformer() : BackgroundTransformer()
+    ..transformer = deserializer is MainIsolateDeserializer
+        ? SyncTransformer()
+        : BackgroundTransformer()
     ..options.baseUrl = baseUrl
     ..options.listFormat = ListFormat.multiCompatible
     ..interceptors.addAll(interceptors)

--- a/test/src/sturdy_http_test.dart
+++ b/test/src/sturdy_http_test.dart
@@ -70,7 +70,8 @@ void main() {
           interceptors: [
             _FakeInterceptor(
               onRequestInvoked: (options) {
-                contentType = options.headers[Headers.contentTypeHeader] as String?;
+                contentType =
+                    options.headers[Headers.contentTypeHeader] as String?;
               },
             )
           ],
@@ -93,7 +94,8 @@ void main() {
           interceptors: [
             _FakeInterceptor(
               onRequestInvoked: (options) {
-                contentType = options.headers[Headers.contentTypeHeader] as String?;
+                contentType =
+                    options.headers[Headers.contentTypeHeader] as String?;
               },
             )
           ],
@@ -128,7 +130,9 @@ void main() {
     });
 
     group('withBaseUrl', () {
-      test('it returns a new instance with correct baseUrl and pre-configured settings', () {
+      test(
+          'it returns a new instance with correct baseUrl and pre-configured settings',
+          () {
         final oldInstance = buildSubject(
           interceptors: [_FakeInterceptor()],
         );
@@ -279,7 +283,8 @@ void main() {
                   )
                   ..whenGet(
                     '/not-foo',
-                    (request) => const NotFoo(notMessage: 'Hello world').toJson(),
+                    (request) =>
+                        const NotFoo(notMessage: 'Hello world').toJson(),
                   )
                   ..whenGet(
                     '/bar',
@@ -289,12 +294,14 @@ void main() {
 
               group('when deserialization succeeds', () {
                 test('it returns parsed model', () async {
-                  final response = await buildSubject().execute<Json, Result<Foo, String>>(
+                  final response =
+                      await buildSubject().execute<Json, Result<Foo, String>>(
                     const GetRequest('/foo'),
                     onResponse: (response) {
                       return response.maybeWhen(
                         ok: (json) => Result.success(Foo.fromJson(json)),
-                        orElse: () => const Result.failure('Not expected: orElse'),
+                        orElse: () =>
+                            const Result.failure('Not expected: orElse'),
                       );
                     },
                   );
@@ -307,13 +314,17 @@ void main() {
               });
 
               group('when deserialization fails', () {
-                test('it emits a decodingError event and rethrows the Exception', () async {
-                  final request = buildSubject().execute<Json, Result<Foo, String>>(
+                test(
+                    'it emits a decodingError event and rethrows the Exception',
+                    () async {
+                  final request =
+                      buildSubject().execute<Json, Result<Foo, String>>(
                     const GetRequest('/not-foo'),
                     onResponse: (response) {
                       return response.maybeWhen(
                         ok: (json) => Result.success(Foo.fromJson(json)),
-                        orElse: () => const Result.failure('Not expected: orElse'),
+                        orElse: () =>
+                            const Result.failure('Not expected: orElse'),
                       );
                     },
                   );
@@ -343,7 +354,8 @@ void main() {
                   );
                 });
                 test('it returns okNoContent', () async {
-                  final response = await buildSubject().execute<void, Result<bool, String>>(
+                  final response =
+                      await buildSubject().execute<void, Result<bool, String>>(
                     const PostRequest(
                       '/foo',
                       data: NetworkRequestBody.empty(),
@@ -351,7 +363,8 @@ void main() {
                     onResponse: (response) {
                       return response.maybeWhen(
                         okNoContent: () => const Result.success(true),
-                        orElse: () => const Result.failure('Not expected: orElse'),
+                        orElse: () =>
+                            const Result.failure('Not expected: orElse'),
                       );
                     },
                   );
@@ -376,7 +389,8 @@ void main() {
                 test(
                   'it returns genericError and isConnectionIssue is false',
                   () async {
-                    final response = await buildSubject().execute<void, Result<bool, String>>(
+                    final response = await buildSubject()
+                        .execute<void, Result<bool, String>>(
                       const PostRequest(
                         '/foo',
                         data: NetworkRequestBody.empty(),
@@ -387,7 +401,8 @@ void main() {
                             expect(isConnectionIssue, isFalse);
                             return const Result.success(true);
                           },
-                          orElse: () => const Result.failure('Not expected: orElse'),
+                          orElse: () =>
+                              const Result.failure('Not expected: orElse'),
                         );
                       },
                     );
@@ -424,7 +439,9 @@ void main() {
                     );
                 });
 
-                test('it emits a MutativeRequestSuccess event with correct path', () async {
+                test(
+                    'it emits a MutativeRequestSuccess event with correct path',
+                    () async {
                   final subject = buildSubject();
                   await Future.wait([
                     subject.execute<Json, Result<String, String>>(
@@ -435,7 +452,8 @@ void main() {
                       onResponse: (response) {
                         return response.maybeWhen(
                           ok: (json) => Result.success(json['foo'] as String),
-                          orElse: () => const Result.failure('Not expected: orElse'),
+                          orElse: () =>
+                              const Result.failure('Not expected: orElse'),
                         );
                       },
                     ),
@@ -447,7 +465,8 @@ void main() {
                       onResponse: (response) {
                         return response.maybeWhen(
                           ok: (json) => Result.success(json['foo'] as String),
-                          orElse: () => const Result.failure('Not expected: orElse'),
+                          orElse: () =>
+                              const Result.failure('Not expected: orElse'),
                         );
                       },
                     ),
@@ -459,7 +478,8 @@ void main() {
                       onResponse: (response) {
                         return response.maybeWhen(
                           ok: (json) => Result.success(json['foo'] as String),
-                          orElse: () => const Result.failure('Not expected: orElse'),
+                          orElse: () =>
+                              const Result.failure('Not expected: orElse'),
                         );
                       },
                     )
@@ -480,7 +500,8 @@ void main() {
                 });
               });
 
-              group('and the response has status codes other than 200 or 204', () {
+              group('and the response has status codes other than 200 or 204',
+                  () {
                 setUp(() {
                   charlatan
                     ..whenPost(
@@ -500,7 +521,8 @@ void main() {
                     );
                 });
 
-                test('it does not emit a MutativeRequestSuccess event', () async {
+                test('it does not emit a MutativeRequestSuccess event',
+                    () async {
                   final subject = buildSubject();
                   await Future.wait([
                     subject.execute<Json, Result<String, String>>(
@@ -511,7 +533,8 @@ void main() {
                       onResponse: (response) {
                         return response.maybeWhen(
                           ok: (json) => Result.success(json['foo'] as String),
-                          orElse: () => const Result.failure('Not expected: orElse'),
+                          orElse: () =>
+                              const Result.failure('Not expected: orElse'),
                         );
                       },
                     ),
@@ -523,7 +546,8 @@ void main() {
                       onResponse: (response) {
                         return response.maybeWhen(
                           ok: (json) => Result.success(json['foo'] as String),
-                          orElse: () => const Result.failure('Not expected: orElse'),
+                          orElse: () =>
+                              const Result.failure('Not expected: orElse'),
                         );
                       },
                     ),
@@ -535,7 +559,8 @@ void main() {
                       onResponse: (response) {
                         return response.maybeWhen(
                           ok: (json) => Result.success(json['foo'] as String),
-                          orElse: () => const Result.failure('Not expected: orElse'),
+                          orElse: () =>
+                              const Result.failure('Not expected: orElse'),
                         );
                       },
                     )
@@ -569,8 +594,10 @@ void main() {
               setupErrorResponse(statusCode: 401);
             });
 
-            test('it emits an authFailure event and invokes unauthorized', () async {
-              final response = await buildSubject().execute<Json, Result<bool, String>>(
+            test('it emits an authFailure event and invokes unauthorized',
+                () async {
+              final response =
+                  await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeMap(
@@ -595,7 +622,8 @@ void main() {
             });
 
             test('it returns forbidden', () async {
-              final response = await buildSubject().execute<Json, Result<bool, String>>(
+              final response =
+                  await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(
@@ -618,7 +646,8 @@ void main() {
             });
 
             test('it returns notFound', () async {
-              final response = await buildSubject().execute<Json, Result<bool, String>>(
+              final response =
+                  await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(
@@ -644,11 +673,13 @@ void main() {
             });
 
             test('it returns unprocessableEntity', () async {
-              final response = await buildSubject().execute<Json, Result<bool, String>>(
+              final response =
+                  await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(
-                    unprocessableEntity: (error, response) => const Result.success(true),
+                    unprocessableEntity: (error, response) =>
+                        const Result.success(true),
                     orElse: () => const Result.failure('Not expected: orElse'),
                   );
                 },
@@ -667,7 +698,8 @@ void main() {
             });
 
             test('it returns serverError', () async {
-              final response = await buildSubject().execute<Json, Result<bool, String>>(
+              final response =
+                  await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(
@@ -690,7 +722,8 @@ void main() {
             });
 
             test('it returns service unavailable', () async {
-              final response = await buildSubject().execute<Json, Result<bool, String>>(
+              final response =
+                  await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(
@@ -713,11 +746,13 @@ void main() {
             });
 
             test('it returns genericError', () async {
-              final response = await buildSubject().execute<Json, Result<bool, String>>(
+              final response =
+                  await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(
-                    genericError: (message, _, error) => const Result.success(true),
+                    genericError: (message, _, error) =>
+                        const Result.success(true),
                     orElse: () => const Result.failure('Not expected: orElse'),
                   );
                 },
@@ -738,8 +773,10 @@ void main() {
               );
             });
 
-            test('it returns genericError and isConnectionIssue is true', () async {
-              final response = await buildSubject().execute<Json, Result<bool, String>>(
+            test('it returns genericError and isConnectionIssue is true',
+                () async {
+              final response =
+                  await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(

--- a/test/src/sturdy_http_test.dart
+++ b/test/src/sturdy_http_test.dart
@@ -42,12 +42,13 @@ void main() {
       bool inferContentType = false,
     }) {
       return SturdyHttp(
-          baseUrl: baseUrl,
-          customAdapter: charlatan.toFakeHttpClientAdapter(),
-          eventListener: eventListener,
-          interceptors: interceptors,
-          proxy: proxy,
-          inferContentType: inferContentType);
+        baseUrl: baseUrl,
+        customAdapter: charlatan.toFakeHttpClientAdapter(),
+        eventListener: eventListener,
+        interceptors: interceptors,
+        proxy: proxy,
+        inferContentType: inferContentType,
+      );
     }
 
     group('interceptors', () {

--- a/test/src/sturdy_http_test.dart
+++ b/test/src/sturdy_http_test.dart
@@ -64,7 +64,7 @@ void main() {
     });
 
     group('inferContentType', () {
-      test('it does not infer when false', () async {
+      test('it does not infer content-type when false', () async {
         String? contentType;
         final subject = buildSubject(
           inferContentType: false,
@@ -88,7 +88,7 @@ void main() {
         expect(contentType, isNull);
       });
 
-      test('it infers when true', () async {
+      test('it infers content-type when true', () async {
         String? contentType;
         final subject = buildSubject(
           inferContentType: true,


### PR DESCRIPTION
### 📰 Summary of changes
<!-- Feel free to delete this section if it doesn't apply -->
> What is the new functionality added in this PR?

This PR is a follow-up to the conversation [here](https://github.com/Betterment/sturdy_http/pull/3#discussion_r1266872202) that touched on a need to reconcile our handling of content type headers. 

We're choosing to lean on the default behavior of `Dio` to infer the `content-type` header but allowing consumers to disable that behavior. **Because of this, this is technically a breaking change because we previously did _not_ infer content-type but are choosing to do so by default now.** Consumers upgrading will be required to set this to `false` if they want to preserve the legacy behavior.

We also add documentation to `NetworkRequestBody` to clarify expectations w/r/t the association between `NetworkRequestBody` and the inferred (or not inferred) content-type header.

### 🧪 Testing done
<!-- Feel free to delete this section if it doesn't apply -->
> What testing was added to cover the functionality added in this PR

Added tests for the same.
