### PR TITLE
feat: support retrying failed requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,20 +15,27 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
+
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+
       - name: Setup dart
         uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f # v1.5.0
         with:
-          sdk: 3.0.7
+          sdk: 3.3.1
+
       - name: Install dependencies
         run: dart pub get
+
       - name: Verify formatting
         run: dart format --output=none --set-exit-if-changed .
+
       - name: Analyze project source
         uses: invertase/github-action-dart-analyzer@1cda5922c6369263b1c7e2fbe281f69704f4d63e #v1.0.0
+
       - name: Run tests and generate coverage report
         run: ./tool/generate_code_coverage.sh
+
       - uses: codecov/codecov-action@40a12dcee2df644d47232dde008099a3e9e4f865 #v3.1.2
         with:
           files: coverage/lcov.info
@@ -38,13 +45,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+
       - name: Setup dart
         uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f # v1.5.0
         with:
-          sdk: 3.0.7
+          sdk: 3.3.1
+
       - name: Install dependencies
         run: |
           dart pub get
           dart pub global activate pana
+
       - name: Verify pub score
         run: ./tool/verify_pub_score.sh

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,6 +5,7 @@ linter:
     - package_api_docs
     - public_member_api_docs
     - sort_pub_dependencies
+    - require_trailing_commas
 
 analyzer:
   language:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "**/*.freezed.dart"
+  - "**/*.g.dart"

--- a/lib/src/network_request.dart
+++ b/lib/src/network_request.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:sturdy_http/src/retry_behavior.dart';
 import 'package:sturdy_http/sturdy_http.dart';
 
 part 'network_request.freezed.dart';
@@ -30,6 +31,7 @@ abstract class NetworkRequest {
     this.cancelToken,
     this.onReceiveProgress,
     this.onSendProgress,
+    this.retryBehavior = const Unspecified(),
   });
 
   /// {@macro network_request_type}
@@ -38,7 +40,7 @@ abstract class NetworkRequest {
   /// The path of the requested resource
   final String path;
 
-  ///
+  /// The body of the network request
   final NetworkRequestBody data;
 
   /// Whether this request should be considered as mutative. If false,
@@ -60,6 +62,10 @@ abstract class NetworkRequest {
 
   /// [ProgressCallback] for send progress for this request
   final ProgressCallback? onSendProgress;
+
+  /// The [RetryBehavior] for this request. Defaults to [Unspecified]. If not
+  /// overridden, the [SturdyHttp] instance's [RetryBehavior] will be used.
+  final RetryBehavior retryBehavior;
 }
 
 /// {@template get_request}
@@ -75,6 +81,7 @@ class GetRequest extends NetworkRequest {
     super.cancelToken,
     super.onReceiveProgress,
     super.onSendProgress,
+    super.retryBehavior,
   }) : super(
           type: NetworkRequestType.Get,
           path: path,
@@ -97,6 +104,7 @@ class PostRequest extends NetworkRequest {
     super.cancelToken,
     super.onReceiveProgress,
     super.onSendProgress,
+    super.retryBehavior,
   }) : super(
           type: NetworkRequestType.Post,
           path: path,
@@ -118,6 +126,7 @@ class PutRequest extends NetworkRequest {
     super.cancelToken,
     super.onReceiveProgress,
     super.onSendProgress,
+    super.retryBehavior,
   }) : super(
           type: NetworkRequestType.Put,
           path: path,
@@ -139,6 +148,7 @@ class DeleteRequest extends NetworkRequest {
     super.cancelToken,
     super.onReceiveProgress,
     super.onSendProgress,
+    super.retryBehavior,
   }) : super(
           type: NetworkRequestType.Delete,
           path: path,
@@ -163,6 +173,7 @@ class RawRequest extends NetworkRequest {
     super.cancelToken,
     super.onReceiveProgress,
     super.onSendProgress,
+    super.retryBehavior,
   }) : super(
           path: path,
           queryParams: queryParameters,

--- a/lib/src/network_request.freezed.dart
+++ b/lib/src/network_request.freezed.dart
@@ -12,7 +12,7 @@ part of 'network_request.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$NetworkRequestBody {
@@ -64,8 +64,8 @@ mixin _$NetworkRequestBody {
 
 /// @nodoc
 
-class _$_Empty implements _Empty {
-  const _$_Empty();
+class _$EmptyImpl implements _Empty {
+  const _$EmptyImpl();
 
   @override
   String toString() {
@@ -73,9 +73,9 @@ class _$_Empty implements _Empty {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$_Empty);
+        (other.runtimeType == runtimeType && other is _$EmptyImpl);
   }
 
   @override
@@ -151,13 +151,13 @@ class _$_Empty implements _Empty {
 }
 
 abstract class _Empty implements NetworkRequestBody {
-  const factory _Empty() = _$_Empty;
+  const factory _Empty() = _$EmptyImpl;
 }
 
 /// @nodoc
 
-class _$_Json implements _Json {
-  const _$_Json(final Map<String, dynamic> data) : _data = data;
+class _$JsonImpl implements _Json {
+  const _$JsonImpl(final Map<String, dynamic> data) : _data = data;
 
   final Map<String, dynamic> _data;
   @override
@@ -173,10 +173,10 @@ class _$_Json implements _Json {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Json &&
+            other is _$JsonImpl &&
             const DeepCollectionEquality().equals(other._data, _data));
   }
 
@@ -254,15 +254,15 @@ class _$_Json implements _Json {
 }
 
 abstract class _Json implements NetworkRequestBody {
-  const factory _Json(final Map<String, dynamic> data) = _$_Json;
+  const factory _Json(final Map<String, dynamic> data) = _$JsonImpl;
 
   Map<String, dynamic> get data;
 }
 
 /// @nodoc
 
-class _$_Raw implements _Raw {
-  const _$_Raw(this.data);
+class _$RawImpl implements _Raw {
+  const _$RawImpl(this.data);
 
   @override
   final Object? data;
@@ -273,10 +273,10 @@ class _$_Raw implements _Raw {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Raw &&
+            other is _$RawImpl &&
             const DeepCollectionEquality().equals(other.data, data));
   }
 
@@ -354,7 +354,7 @@ class _$_Raw implements _Raw {
 }
 
 abstract class _Raw implements NetworkRequestBody {
-  const factory _Raw(final Object? data) = _$_Raw;
+  const factory _Raw(final Object? data) = _$RawImpl;
 
   Object? get data;
 }

--- a/lib/src/network_response.freezed.dart
+++ b/lib/src/network_response.freezed.dart
@@ -12,7 +12,7 @@ part of 'network_response.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$NetworkResponse<R> {
@@ -125,18 +125,19 @@ class _$NetworkResponseCopyWithImpl<R, $Res, $Val extends NetworkResponse<R>>
 }
 
 /// @nodoc
-abstract class _$$_OkCopyWith<R, $Res> {
-  factory _$$_OkCopyWith(_$_Ok<R> value, $Res Function(_$_Ok<R>) then) =
-      __$$_OkCopyWithImpl<R, $Res>;
+abstract class _$$OkImplCopyWith<R, $Res> {
+  factory _$$OkImplCopyWith(
+          _$OkImpl<R> value, $Res Function(_$OkImpl<R>) then) =
+      __$$OkImplCopyWithImpl<R, $Res>;
   @useResult
   $Res call({R response});
 }
 
 /// @nodoc
-class __$$_OkCopyWithImpl<R, $Res>
-    extends _$NetworkResponseCopyWithImpl<R, $Res, _$_Ok<R>>
-    implements _$$_OkCopyWith<R, $Res> {
-  __$$_OkCopyWithImpl(_$_Ok<R> _value, $Res Function(_$_Ok<R>) _then)
+class __$$OkImplCopyWithImpl<R, $Res>
+    extends _$NetworkResponseCopyWithImpl<R, $Res, _$OkImpl<R>>
+    implements _$$OkImplCopyWith<R, $Res> {
+  __$$OkImplCopyWithImpl(_$OkImpl<R> _value, $Res Function(_$OkImpl<R>) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -144,7 +145,7 @@ class __$$_OkCopyWithImpl<R, $Res>
   $Res call({
     Object? response = freezed,
   }) {
-    return _then(_$_Ok<R>(
+    return _then(_$OkImpl<R>(
       freezed == response
           ? _value.response
           : response // ignore: cast_nullable_to_non_nullable
@@ -155,8 +156,8 @@ class __$$_OkCopyWithImpl<R, $Res>
 
 /// @nodoc
 
-class _$_Ok<R> implements _Ok<R> {
-  const _$_Ok(this.response);
+class _$OkImpl<R> implements _Ok<R> {
+  const _$OkImpl(this.response);
 
   @override
   final R response;
@@ -167,10 +168,10 @@ class _$_Ok<R> implements _Ok<R> {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Ok<R> &&
+            other is _$OkImpl<R> &&
             const DeepCollectionEquality().equals(other.response, response));
   }
 
@@ -181,8 +182,8 @@ class _$_Ok<R> implements _Ok<R> {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_OkCopyWith<R, _$_Ok<R>> get copyWith =>
-      __$$_OkCopyWithImpl<R, _$_Ok<R>>(this, _$identity);
+  _$$OkImplCopyWith<R, _$OkImpl<R>> get copyWith =>
+      __$$OkImplCopyWithImpl<R, _$OkImpl<R>>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -298,34 +299,34 @@ class _$_Ok<R> implements _Ok<R> {
 }
 
 abstract class _Ok<R> implements NetworkResponse<R> {
-  const factory _Ok(final R response) = _$_Ok<R>;
+  const factory _Ok(final R response) = _$OkImpl<R>;
 
   R get response;
   @JsonKey(ignore: true)
-  _$$_OkCopyWith<R, _$_Ok<R>> get copyWith =>
+  _$$OkImplCopyWith<R, _$OkImpl<R>> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_OkNoContentCopyWith<R, $Res> {
-  factory _$$_OkNoContentCopyWith(
-          _$_OkNoContent<R> value, $Res Function(_$_OkNoContent<R>) then) =
-      __$$_OkNoContentCopyWithImpl<R, $Res>;
+abstract class _$$OkNoContentImplCopyWith<R, $Res> {
+  factory _$$OkNoContentImplCopyWith(_$OkNoContentImpl<R> value,
+          $Res Function(_$OkNoContentImpl<R>) then) =
+      __$$OkNoContentImplCopyWithImpl<R, $Res>;
 }
 
 /// @nodoc
-class __$$_OkNoContentCopyWithImpl<R, $Res>
-    extends _$NetworkResponseCopyWithImpl<R, $Res, _$_OkNoContent<R>>
-    implements _$$_OkNoContentCopyWith<R, $Res> {
-  __$$_OkNoContentCopyWithImpl(
-      _$_OkNoContent<R> _value, $Res Function(_$_OkNoContent<R>) _then)
+class __$$OkNoContentImplCopyWithImpl<R, $Res>
+    extends _$NetworkResponseCopyWithImpl<R, $Res, _$OkNoContentImpl<R>>
+    implements _$$OkNoContentImplCopyWith<R, $Res> {
+  __$$OkNoContentImplCopyWithImpl(
+      _$OkNoContentImpl<R> _value, $Res Function(_$OkNoContentImpl<R>) _then)
       : super(_value, _then);
 }
 
 /// @nodoc
 
-class _$_OkNoContent<R> implements _OkNoContent<R> {
-  const _$_OkNoContent();
+class _$OkNoContentImpl<R> implements _OkNoContent<R> {
+  const _$OkNoContentImpl();
 
   @override
   String toString() {
@@ -333,9 +334,9 @@ class _$_OkNoContent<R> implements _OkNoContent<R> {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$_OkNoContent<R>);
+        (other.runtimeType == runtimeType && other is _$OkNoContentImpl<R>);
   }
 
   @override
@@ -455,24 +456,24 @@ class _$_OkNoContent<R> implements _OkNoContent<R> {
 }
 
 abstract class _OkNoContent<R> implements NetworkResponse<R> {
-  const factory _OkNoContent() = _$_OkNoContent<R>;
+  const factory _OkNoContent() = _$OkNoContentImpl<R>;
 }
 
 /// @nodoc
-abstract class _$$_UnauthorizedCopyWith<R, $Res> {
-  factory _$$_UnauthorizedCopyWith(
-          _$_Unauthorized<R> value, $Res Function(_$_Unauthorized<R>) then) =
-      __$$_UnauthorizedCopyWithImpl<R, $Res>;
+abstract class _$$UnauthorizedImplCopyWith<R, $Res> {
+  factory _$$UnauthorizedImplCopyWith(_$UnauthorizedImpl<R> value,
+          $Res Function(_$UnauthorizedImpl<R>) then) =
+      __$$UnauthorizedImplCopyWithImpl<R, $Res>;
   @useResult
   $Res call({DioException error});
 }
 
 /// @nodoc
-class __$$_UnauthorizedCopyWithImpl<R, $Res>
-    extends _$NetworkResponseCopyWithImpl<R, $Res, _$_Unauthorized<R>>
-    implements _$$_UnauthorizedCopyWith<R, $Res> {
-  __$$_UnauthorizedCopyWithImpl(
-      _$_Unauthorized<R> _value, $Res Function(_$_Unauthorized<R>) _then)
+class __$$UnauthorizedImplCopyWithImpl<R, $Res>
+    extends _$NetworkResponseCopyWithImpl<R, $Res, _$UnauthorizedImpl<R>>
+    implements _$$UnauthorizedImplCopyWith<R, $Res> {
+  __$$UnauthorizedImplCopyWithImpl(
+      _$UnauthorizedImpl<R> _value, $Res Function(_$UnauthorizedImpl<R>) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -480,7 +481,7 @@ class __$$_UnauthorizedCopyWithImpl<R, $Res>
   $Res call({
     Object? error = null,
   }) {
-    return _then(_$_Unauthorized<R>(
+    return _then(_$UnauthorizedImpl<R>(
       null == error
           ? _value.error
           : error // ignore: cast_nullable_to_non_nullable
@@ -491,8 +492,8 @@ class __$$_UnauthorizedCopyWithImpl<R, $Res>
 
 /// @nodoc
 
-class _$_Unauthorized<R> implements _Unauthorized<R> {
-  const _$_Unauthorized(this.error);
+class _$UnauthorizedImpl<R> implements _Unauthorized<R> {
+  const _$UnauthorizedImpl(this.error);
 
   @override
   final DioException error;
@@ -503,10 +504,10 @@ class _$_Unauthorized<R> implements _Unauthorized<R> {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Unauthorized<R> &&
+            other is _$UnauthorizedImpl<R> &&
             (identical(other.error, error) || other.error == error));
   }
 
@@ -516,8 +517,9 @@ class _$_Unauthorized<R> implements _Unauthorized<R> {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_UnauthorizedCopyWith<R, _$_Unauthorized<R>> get copyWith =>
-      __$$_UnauthorizedCopyWithImpl<R, _$_Unauthorized<R>>(this, _$identity);
+  _$$UnauthorizedImplCopyWith<R, _$UnauthorizedImpl<R>> get copyWith =>
+      __$$UnauthorizedImplCopyWithImpl<R, _$UnauthorizedImpl<R>>(
+          this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -633,29 +635,29 @@ class _$_Unauthorized<R> implements _Unauthorized<R> {
 }
 
 abstract class _Unauthorized<R> implements NetworkResponse<R> {
-  const factory _Unauthorized(final DioException error) = _$_Unauthorized<R>;
+  const factory _Unauthorized(final DioException error) = _$UnauthorizedImpl<R>;
 
   DioException get error;
   @JsonKey(ignore: true)
-  _$$_UnauthorizedCopyWith<R, _$_Unauthorized<R>> get copyWith =>
+  _$$UnauthorizedImplCopyWith<R, _$UnauthorizedImpl<R>> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_ForbiddenCopyWith<R, $Res> {
-  factory _$$_ForbiddenCopyWith(
-          _$_Forbidden<R> value, $Res Function(_$_Forbidden<R>) then) =
-      __$$_ForbiddenCopyWithImpl<R, $Res>;
+abstract class _$$ForbiddenImplCopyWith<R, $Res> {
+  factory _$$ForbiddenImplCopyWith(
+          _$ForbiddenImpl<R> value, $Res Function(_$ForbiddenImpl<R>) then) =
+      __$$ForbiddenImplCopyWithImpl<R, $Res>;
   @useResult
   $Res call({DioException error});
 }
 
 /// @nodoc
-class __$$_ForbiddenCopyWithImpl<R, $Res>
-    extends _$NetworkResponseCopyWithImpl<R, $Res, _$_Forbidden<R>>
-    implements _$$_ForbiddenCopyWith<R, $Res> {
-  __$$_ForbiddenCopyWithImpl(
-      _$_Forbidden<R> _value, $Res Function(_$_Forbidden<R>) _then)
+class __$$ForbiddenImplCopyWithImpl<R, $Res>
+    extends _$NetworkResponseCopyWithImpl<R, $Res, _$ForbiddenImpl<R>>
+    implements _$$ForbiddenImplCopyWith<R, $Res> {
+  __$$ForbiddenImplCopyWithImpl(
+      _$ForbiddenImpl<R> _value, $Res Function(_$ForbiddenImpl<R>) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -663,7 +665,7 @@ class __$$_ForbiddenCopyWithImpl<R, $Res>
   $Res call({
     Object? error = null,
   }) {
-    return _then(_$_Forbidden<R>(
+    return _then(_$ForbiddenImpl<R>(
       null == error
           ? _value.error
           : error // ignore: cast_nullable_to_non_nullable
@@ -674,8 +676,8 @@ class __$$_ForbiddenCopyWithImpl<R, $Res>
 
 /// @nodoc
 
-class _$_Forbidden<R> implements _Forbidden<R> {
-  const _$_Forbidden(this.error);
+class _$ForbiddenImpl<R> implements _Forbidden<R> {
+  const _$ForbiddenImpl(this.error);
 
   @override
   final DioException error;
@@ -686,10 +688,10 @@ class _$_Forbidden<R> implements _Forbidden<R> {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Forbidden<R> &&
+            other is _$ForbiddenImpl<R> &&
             (identical(other.error, error) || other.error == error));
   }
 
@@ -699,8 +701,8 @@ class _$_Forbidden<R> implements _Forbidden<R> {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ForbiddenCopyWith<R, _$_Forbidden<R>> get copyWith =>
-      __$$_ForbiddenCopyWithImpl<R, _$_Forbidden<R>>(this, _$identity);
+  _$$ForbiddenImplCopyWith<R, _$ForbiddenImpl<R>> get copyWith =>
+      __$$ForbiddenImplCopyWithImpl<R, _$ForbiddenImpl<R>>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -816,29 +818,29 @@ class _$_Forbidden<R> implements _Forbidden<R> {
 }
 
 abstract class _Forbidden<R> implements NetworkResponse<R> {
-  const factory _Forbidden(final DioException error) = _$_Forbidden<R>;
+  const factory _Forbidden(final DioException error) = _$ForbiddenImpl<R>;
 
   DioException get error;
   @JsonKey(ignore: true)
-  _$$_ForbiddenCopyWith<R, _$_Forbidden<R>> get copyWith =>
+  _$$ForbiddenImplCopyWith<R, _$ForbiddenImpl<R>> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_NotFoundCopyWith<R, $Res> {
-  factory _$$_NotFoundCopyWith(
-          _$_NotFound<R> value, $Res Function(_$_NotFound<R>) then) =
-      __$$_NotFoundCopyWithImpl<R, $Res>;
+abstract class _$$NotFoundImplCopyWith<R, $Res> {
+  factory _$$NotFoundImplCopyWith(
+          _$NotFoundImpl<R> value, $Res Function(_$NotFoundImpl<R>) then) =
+      __$$NotFoundImplCopyWithImpl<R, $Res>;
   @useResult
   $Res call({DioException error});
 }
 
 /// @nodoc
-class __$$_NotFoundCopyWithImpl<R, $Res>
-    extends _$NetworkResponseCopyWithImpl<R, $Res, _$_NotFound<R>>
-    implements _$$_NotFoundCopyWith<R, $Res> {
-  __$$_NotFoundCopyWithImpl(
-      _$_NotFound<R> _value, $Res Function(_$_NotFound<R>) _then)
+class __$$NotFoundImplCopyWithImpl<R, $Res>
+    extends _$NetworkResponseCopyWithImpl<R, $Res, _$NotFoundImpl<R>>
+    implements _$$NotFoundImplCopyWith<R, $Res> {
+  __$$NotFoundImplCopyWithImpl(
+      _$NotFoundImpl<R> _value, $Res Function(_$NotFoundImpl<R>) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -846,7 +848,7 @@ class __$$_NotFoundCopyWithImpl<R, $Res>
   $Res call({
     Object? error = null,
   }) {
-    return _then(_$_NotFound<R>(
+    return _then(_$NotFoundImpl<R>(
       null == error
           ? _value.error
           : error // ignore: cast_nullable_to_non_nullable
@@ -857,8 +859,8 @@ class __$$_NotFoundCopyWithImpl<R, $Res>
 
 /// @nodoc
 
-class _$_NotFound<R> implements _NotFound<R> {
-  const _$_NotFound(this.error);
+class _$NotFoundImpl<R> implements _NotFound<R> {
+  const _$NotFoundImpl(this.error);
 
   @override
   final DioException error;
@@ -869,10 +871,10 @@ class _$_NotFound<R> implements _NotFound<R> {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_NotFound<R> &&
+            other is _$NotFoundImpl<R> &&
             (identical(other.error, error) || other.error == error));
   }
 
@@ -882,8 +884,8 @@ class _$_NotFound<R> implements _NotFound<R> {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_NotFoundCopyWith<R, _$_NotFound<R>> get copyWith =>
-      __$$_NotFoundCopyWithImpl<R, _$_NotFound<R>>(this, _$identity);
+  _$$NotFoundImplCopyWith<R, _$NotFoundImpl<R>> get copyWith =>
+      __$$NotFoundImplCopyWithImpl<R, _$NotFoundImpl<R>>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -999,29 +1001,29 @@ class _$_NotFound<R> implements _NotFound<R> {
 }
 
 abstract class _NotFound<R> implements NetworkResponse<R> {
-  const factory _NotFound(final DioException error) = _$_NotFound<R>;
+  const factory _NotFound(final DioException error) = _$NotFoundImpl<R>;
 
   DioException get error;
   @JsonKey(ignore: true)
-  _$$_NotFoundCopyWith<R, _$_NotFound<R>> get copyWith =>
+  _$$NotFoundImplCopyWith<R, _$NotFoundImpl<R>> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_UnprocessableEntityCopyWith<R, $Res> {
-  factory _$$_UnprocessableEntityCopyWith(_$_UnprocessableEntity<R> value,
-          $Res Function(_$_UnprocessableEntity<R>) then) =
-      __$$_UnprocessableEntityCopyWithImpl<R, $Res>;
+abstract class _$$UnprocessableEntityImplCopyWith<R, $Res> {
+  factory _$$UnprocessableEntityImplCopyWith(_$UnprocessableEntityImpl<R> value,
+          $Res Function(_$UnprocessableEntityImpl<R>) then) =
+      __$$UnprocessableEntityImplCopyWithImpl<R, $Res>;
   @useResult
   $Res call({DioException error, R response});
 }
 
 /// @nodoc
-class __$$_UnprocessableEntityCopyWithImpl<R, $Res>
-    extends _$NetworkResponseCopyWithImpl<R, $Res, _$_UnprocessableEntity<R>>
-    implements _$$_UnprocessableEntityCopyWith<R, $Res> {
-  __$$_UnprocessableEntityCopyWithImpl(_$_UnprocessableEntity<R> _value,
-      $Res Function(_$_UnprocessableEntity<R>) _then)
+class __$$UnprocessableEntityImplCopyWithImpl<R, $Res>
+    extends _$NetworkResponseCopyWithImpl<R, $Res, _$UnprocessableEntityImpl<R>>
+    implements _$$UnprocessableEntityImplCopyWith<R, $Res> {
+  __$$UnprocessableEntityImplCopyWithImpl(_$UnprocessableEntityImpl<R> _value,
+      $Res Function(_$UnprocessableEntityImpl<R>) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1030,7 +1032,7 @@ class __$$_UnprocessableEntityCopyWithImpl<R, $Res>
     Object? error = null,
     Object? response = freezed,
   }) {
-    return _then(_$_UnprocessableEntity<R>(
+    return _then(_$UnprocessableEntityImpl<R>(
       error: null == error
           ? _value.error
           : error // ignore: cast_nullable_to_non_nullable
@@ -1045,8 +1047,9 @@ class __$$_UnprocessableEntityCopyWithImpl<R, $Res>
 
 /// @nodoc
 
-class _$_UnprocessableEntity<R> implements _UnprocessableEntity<R> {
-  const _$_UnprocessableEntity({required this.error, required this.response});
+class _$UnprocessableEntityImpl<R> implements _UnprocessableEntity<R> {
+  const _$UnprocessableEntityImpl(
+      {required this.error, required this.response});
 
   @override
   final DioException error;
@@ -1059,10 +1062,10 @@ class _$_UnprocessableEntity<R> implements _UnprocessableEntity<R> {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_UnprocessableEntity<R> &&
+            other is _$UnprocessableEntityImpl<R> &&
             (identical(other.error, error) || other.error == error) &&
             const DeepCollectionEquality().equals(other.response, response));
   }
@@ -1074,9 +1077,9 @@ class _$_UnprocessableEntity<R> implements _UnprocessableEntity<R> {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_UnprocessableEntityCopyWith<R, _$_UnprocessableEntity<R>> get copyWith =>
-      __$$_UnprocessableEntityCopyWithImpl<R, _$_UnprocessableEntity<R>>(
-          this, _$identity);
+  _$$UnprocessableEntityImplCopyWith<R, _$UnprocessableEntityImpl<R>>
+      get copyWith => __$$UnprocessableEntityImplCopyWithImpl<R,
+          _$UnprocessableEntityImpl<R>>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1194,30 +1197,30 @@ class _$_UnprocessableEntity<R> implements _UnprocessableEntity<R> {
 abstract class _UnprocessableEntity<R> implements NetworkResponse<R> {
   const factory _UnprocessableEntity(
       {required final DioException error,
-      required final R response}) = _$_UnprocessableEntity<R>;
+      required final R response}) = _$UnprocessableEntityImpl<R>;
 
   DioException get error;
   R get response;
   @JsonKey(ignore: true)
-  _$$_UnprocessableEntityCopyWith<R, _$_UnprocessableEntity<R>> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$UnprocessableEntityImplCopyWith<R, _$UnprocessableEntityImpl<R>>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_ServerErrorCopyWith<R, $Res> {
-  factory _$$_ServerErrorCopyWith(
-          _$_ServerError<R> value, $Res Function(_$_ServerError<R>) then) =
-      __$$_ServerErrorCopyWithImpl<R, $Res>;
+abstract class _$$ServerErrorImplCopyWith<R, $Res> {
+  factory _$$ServerErrorImplCopyWith(_$ServerErrorImpl<R> value,
+          $Res Function(_$ServerErrorImpl<R>) then) =
+      __$$ServerErrorImplCopyWithImpl<R, $Res>;
   @useResult
   $Res call({DioException error});
 }
 
 /// @nodoc
-class __$$_ServerErrorCopyWithImpl<R, $Res>
-    extends _$NetworkResponseCopyWithImpl<R, $Res, _$_ServerError<R>>
-    implements _$$_ServerErrorCopyWith<R, $Res> {
-  __$$_ServerErrorCopyWithImpl(
-      _$_ServerError<R> _value, $Res Function(_$_ServerError<R>) _then)
+class __$$ServerErrorImplCopyWithImpl<R, $Res>
+    extends _$NetworkResponseCopyWithImpl<R, $Res, _$ServerErrorImpl<R>>
+    implements _$$ServerErrorImplCopyWith<R, $Res> {
+  __$$ServerErrorImplCopyWithImpl(
+      _$ServerErrorImpl<R> _value, $Res Function(_$ServerErrorImpl<R>) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1225,7 +1228,7 @@ class __$$_ServerErrorCopyWithImpl<R, $Res>
   $Res call({
     Object? error = null,
   }) {
-    return _then(_$_ServerError<R>(
+    return _then(_$ServerErrorImpl<R>(
       null == error
           ? _value.error
           : error // ignore: cast_nullable_to_non_nullable
@@ -1236,8 +1239,8 @@ class __$$_ServerErrorCopyWithImpl<R, $Res>
 
 /// @nodoc
 
-class _$_ServerError<R> implements _ServerError<R> {
-  const _$_ServerError(this.error);
+class _$ServerErrorImpl<R> implements _ServerError<R> {
+  const _$ServerErrorImpl(this.error);
 
   @override
   final DioException error;
@@ -1248,10 +1251,10 @@ class _$_ServerError<R> implements _ServerError<R> {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ServerError<R> &&
+            other is _$ServerErrorImpl<R> &&
             (identical(other.error, error) || other.error == error));
   }
 
@@ -1261,8 +1264,9 @@ class _$_ServerError<R> implements _ServerError<R> {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ServerErrorCopyWith<R, _$_ServerError<R>> get copyWith =>
-      __$$_ServerErrorCopyWithImpl<R, _$_ServerError<R>>(this, _$identity);
+  _$$ServerErrorImplCopyWith<R, _$ServerErrorImpl<R>> get copyWith =>
+      __$$ServerErrorImplCopyWithImpl<R, _$ServerErrorImpl<R>>(
+          this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1378,29 +1382,29 @@ class _$_ServerError<R> implements _ServerError<R> {
 }
 
 abstract class _ServerError<R> implements NetworkResponse<R> {
-  const factory _ServerError(final DioException error) = _$_ServerError<R>;
+  const factory _ServerError(final DioException error) = _$ServerErrorImpl<R>;
 
   DioException get error;
   @JsonKey(ignore: true)
-  _$$_ServerErrorCopyWith<R, _$_ServerError<R>> get copyWith =>
+  _$$ServerErrorImplCopyWith<R, _$ServerErrorImpl<R>> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_ServiceUnavailableCopyWith<R, $Res> {
-  factory _$$_ServiceUnavailableCopyWith(_$_ServiceUnavailable<R> value,
-          $Res Function(_$_ServiceUnavailable<R>) then) =
-      __$$_ServiceUnavailableCopyWithImpl<R, $Res>;
+abstract class _$$ServiceUnavailableImplCopyWith<R, $Res> {
+  factory _$$ServiceUnavailableImplCopyWith(_$ServiceUnavailableImpl<R> value,
+          $Res Function(_$ServiceUnavailableImpl<R>) then) =
+      __$$ServiceUnavailableImplCopyWithImpl<R, $Res>;
   @useResult
   $Res call({DioException error});
 }
 
 /// @nodoc
-class __$$_ServiceUnavailableCopyWithImpl<R, $Res>
-    extends _$NetworkResponseCopyWithImpl<R, $Res, _$_ServiceUnavailable<R>>
-    implements _$$_ServiceUnavailableCopyWith<R, $Res> {
-  __$$_ServiceUnavailableCopyWithImpl(_$_ServiceUnavailable<R> _value,
-      $Res Function(_$_ServiceUnavailable<R>) _then)
+class __$$ServiceUnavailableImplCopyWithImpl<R, $Res>
+    extends _$NetworkResponseCopyWithImpl<R, $Res, _$ServiceUnavailableImpl<R>>
+    implements _$$ServiceUnavailableImplCopyWith<R, $Res> {
+  __$$ServiceUnavailableImplCopyWithImpl(_$ServiceUnavailableImpl<R> _value,
+      $Res Function(_$ServiceUnavailableImpl<R>) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1408,7 +1412,7 @@ class __$$_ServiceUnavailableCopyWithImpl<R, $Res>
   $Res call({
     Object? error = null,
   }) {
-    return _then(_$_ServiceUnavailable<R>(
+    return _then(_$ServiceUnavailableImpl<R>(
       null == error
           ? _value.error
           : error // ignore: cast_nullable_to_non_nullable
@@ -1419,8 +1423,8 @@ class __$$_ServiceUnavailableCopyWithImpl<R, $Res>
 
 /// @nodoc
 
-class _$_ServiceUnavailable<R> implements _ServiceUnavailable<R> {
-  const _$_ServiceUnavailable(this.error);
+class _$ServiceUnavailableImpl<R> implements _ServiceUnavailable<R> {
+  const _$ServiceUnavailableImpl(this.error);
 
   @override
   final DioException error;
@@ -1431,10 +1435,10 @@ class _$_ServiceUnavailable<R> implements _ServiceUnavailable<R> {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ServiceUnavailable<R> &&
+            other is _$ServiceUnavailableImpl<R> &&
             (identical(other.error, error) || other.error == error));
   }
 
@@ -1444,9 +1448,9 @@ class _$_ServiceUnavailable<R> implements _ServiceUnavailable<R> {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ServiceUnavailableCopyWith<R, _$_ServiceUnavailable<R>> get copyWith =>
-      __$$_ServiceUnavailableCopyWithImpl<R, _$_ServiceUnavailable<R>>(
-          this, _$identity);
+  _$$ServiceUnavailableImplCopyWith<R, _$ServiceUnavailableImpl<R>>
+      get copyWith => __$$ServiceUnavailableImplCopyWithImpl<R,
+          _$ServiceUnavailableImpl<R>>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1563,29 +1567,29 @@ class _$_ServiceUnavailable<R> implements _ServiceUnavailable<R> {
 
 abstract class _ServiceUnavailable<R> implements NetworkResponse<R> {
   const factory _ServiceUnavailable(final DioException error) =
-      _$_ServiceUnavailable<R>;
+      _$ServiceUnavailableImpl<R>;
 
   DioException get error;
   @JsonKey(ignore: true)
-  _$$_ServiceUnavailableCopyWith<R, _$_ServiceUnavailable<R>> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$ServiceUnavailableImplCopyWith<R, _$ServiceUnavailableImpl<R>>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_GenericErrorCopyWith<R, $Res> {
-  factory _$$_GenericErrorCopyWith(
-          _$_GenericError<R> value, $Res Function(_$_GenericError<R>) then) =
-      __$$_GenericErrorCopyWithImpl<R, $Res>;
+abstract class _$$GenericErrorImplCopyWith<R, $Res> {
+  factory _$$GenericErrorImplCopyWith(_$GenericErrorImpl<R> value,
+          $Res Function(_$GenericErrorImpl<R>) then) =
+      __$$GenericErrorImplCopyWithImpl<R, $Res>;
   @useResult
   $Res call({String message, bool isConnectionIssue, DioException? error});
 }
 
 /// @nodoc
-class __$$_GenericErrorCopyWithImpl<R, $Res>
-    extends _$NetworkResponseCopyWithImpl<R, $Res, _$_GenericError<R>>
-    implements _$$_GenericErrorCopyWith<R, $Res> {
-  __$$_GenericErrorCopyWithImpl(
-      _$_GenericError<R> _value, $Res Function(_$_GenericError<R>) _then)
+class __$$GenericErrorImplCopyWithImpl<R, $Res>
+    extends _$NetworkResponseCopyWithImpl<R, $Res, _$GenericErrorImpl<R>>
+    implements _$$GenericErrorImplCopyWith<R, $Res> {
+  __$$GenericErrorImplCopyWithImpl(
+      _$GenericErrorImpl<R> _value, $Res Function(_$GenericErrorImpl<R>) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -1595,7 +1599,7 @@ class __$$_GenericErrorCopyWithImpl<R, $Res>
     Object? isConnectionIssue = null,
     Object? error = freezed,
   }) {
-    return _then(_$_GenericError<R>(
+    return _then(_$GenericErrorImpl<R>(
       message: null == message
           ? _value.message
           : message // ignore: cast_nullable_to_non_nullable
@@ -1614,8 +1618,8 @@ class __$$_GenericErrorCopyWithImpl<R, $Res>
 
 /// @nodoc
 
-class _$_GenericError<R> implements _GenericError<R> {
-  const _$_GenericError(
+class _$GenericErrorImpl<R> implements _GenericError<R> {
+  const _$GenericErrorImpl(
       {required this.message, required this.isConnectionIssue, this.error});
 
   @override
@@ -1631,10 +1635,10 @@ class _$_GenericError<R> implements _GenericError<R> {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_GenericError<R> &&
+            other is _$GenericErrorImpl<R> &&
             (identical(other.message, message) || other.message == message) &&
             (identical(other.isConnectionIssue, isConnectionIssue) ||
                 other.isConnectionIssue == isConnectionIssue) &&
@@ -1648,8 +1652,9 @@ class _$_GenericError<R> implements _GenericError<R> {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_GenericErrorCopyWith<R, _$_GenericError<R>> get copyWith =>
-      __$$_GenericErrorCopyWithImpl<R, _$_GenericError<R>>(this, _$identity);
+  _$$GenericErrorImplCopyWith<R, _$GenericErrorImpl<R>> get copyWith =>
+      __$$GenericErrorImplCopyWithImpl<R, _$GenericErrorImpl<R>>(
+          this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1768,12 +1773,12 @@ abstract class _GenericError<R> implements NetworkResponse<R> {
   const factory _GenericError(
       {required final String message,
       required final bool isConnectionIssue,
-      final DioException? error}) = _$_GenericError<R>;
+      final DioException? error}) = _$GenericErrorImpl<R>;
 
   String get message;
   bool get isConnectionIssue;
   DioException? get error;
   @JsonKey(ignore: true)
-  _$$_GenericErrorCopyWith<R, _$_GenericError<R>> get copyWith =>
+  _$$GenericErrorImplCopyWith<R, _$GenericErrorImpl<R>> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/retry_behavior.dart
+++ b/lib/src/retry_behavior.dart
@@ -1,0 +1,110 @@
+import 'package:dio/dio.dart';
+
+/// Specifies how a failed network request should be handled as it relates
+/// to retrying the request.
+sealed class RetryBehavior {
+  const RetryBehavior();
+}
+
+/// {@template unspecified}
+/// Indicates that the behavior for retrying a request is unspecified.
+///
+/// This helps differentiate between an intent to never retry and an intent
+/// to defer the decision to something else.
+/// {@endtemplate}
+class Unspecified extends RetryBehavior {
+  /// {@macro unspecified}
+  const Unspecified();
+}
+
+/// {@template never_retry}
+/// Indicates that a request should never be retried.
+/// {@endtemplate}
+class NeverRetry extends RetryBehavior {
+  /// {@macro never_retry}
+  const NeverRetry();
+}
+
+/// {@template retry_clause}
+/// A function that returns `true` if the given `Response` [r] should be retried.
+/// {@endtemplate}
+typedef RetryClause = bool Function(Response<Object?>? r);
+
+/// {@template retry}
+/// Indicates that a request should be retried up to [maxRetries] times with
+/// a delay of [retryInterval] between each attempt. Optionally, a [RetryClause]
+/// can be provided to further customize the retry behavior.
+/// {@endtemplate}
+class Retry extends RetryBehavior {
+  /// The maximum number of times to retry a request. Must be greater than 0
+  /// to have an effect. If `maxRetries` is 1, the request will be attempted
+  /// two times total (the initial request and one retry).
+  final int maxRetries;
+
+  /// The duration to wait between each retry attempt. Must be greater than 0
+  /// to have an effect.
+  final Duration retryInterval;
+
+  /// An optional [RetryClause] that can be used to further customize the
+  /// retry behavior.
+  ///
+  /// This will only be invoked until [maxRetries] is exhausted.
+  final RetryClause? retryClause;
+
+  /// {@macro retry}
+  const Retry({
+    required this.maxRetries,
+    required this.retryInterval,
+    this.retryClause,
+  });
+}
+
+/// Extensions on the [RetryBehavior] type.
+extension RetryBehaviorX on RetryBehavior {
+  /// Returns `true` if the request should be retried based on the given
+  /// [response] and [retryCount].
+  bool shouldRetry(Response<Object?>? response, int retryCount) {
+    return switch (this) {
+      Retry(:final maxRetries, :final retryClause) => () {
+          if (retryCount >= maxRetries) return false;
+          return retryClause?.call(response) ?? defaultRetryClause(response);
+        }(),
+      _ => false,
+    };
+  }
+}
+
+/// The default status codes that will trigger a retry.
+///
+/// This list can not be modified, so be sure to copy it if used in a custom
+/// [RetryClause]. For example:
+/// ```dart
+/// final statusCodes = List<int>.from(defaultRetryStatusCodes);
+/// // Modify statusCodes as needed
+/// ```
+const defaultRetryStatusCodes = [
+  408, // Request Timeout
+  429, // Too Many Requests
+  500, // Internal Server Error
+  502, // Bad Gateway
+  503, // Service Unavailable
+  504, // Gateway Timeout
+  440, // Login Timeout
+  460, // ClientClosedRequest (AWS Elastic Load Balancer)
+  499, // Client Closed Request (Nginx)
+  520, // Unknown Error
+  521, // Web Server Is Down
+  522, // Connection Timed Out
+  523, // Origin Is Unreachable
+  524, // A Timeout Occurred
+  525, // SSL Handshake Failed
+  527, // Railgun Error
+  598, // Network Read Timeout Error
+  599, // Network Connect Timeout Error
+];
+
+/// The default [RetryClause] to be used when [Retry] is specified without
+/// a custom [RetryClause].
+bool defaultRetryClause(Response<Object?>? r) {
+  return r == null || defaultRetryStatusCodes.contains(r.statusCode);
+}

--- a/lib/src/retry_behavior.dart
+++ b/lib/src/retry_behavior.dart
@@ -85,13 +85,13 @@ extension RetryBehaviorX on RetryBehavior {
 const defaultRetryStatusCodes = [
   408, // Request Timeout
   429, // Too Many Requests
+  440, // Login Timeout
+  460, // ClientClosedRequest (AWS Elastic Load Balancer)
+  499, // Client Closed Request (Nginx)
   500, // Internal Server Error
   502, // Bad Gateway
   503, // Service Unavailable
   504, // Gateway Timeout
-  440, // Login Timeout
-  460, // ClientClosedRequest (AWS Elastic Load Balancer)
-  499, // Client Closed Request (Nginx)
   520, // Unknown Error
   521, // Web Server Is Down
   522, // Connection Timed Out

--- a/lib/src/sturdy_http.dart
+++ b/lib/src/sturdy_http.dart
@@ -4,6 +4,7 @@ import 'dart:isolate';
 import 'package:collection/collection.dart';
 import 'package:dio/dio.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:sturdy_http/src/retry_behavior.dart';
 import 'package:sturdy_http/sturdy_http.dart';
 import 'package:uuid/uuid.dart';
 
@@ -28,6 +29,7 @@ class SturdyHttp {
   final Dio _dio;
   final Deserializer _deserializer;
   final SturdyHttpEventListener? _eventListener;
+  final RetryBehavior _retryBehavior;
 
   /// The interceptors provided when this [SturdyHttp] was constructed.
   UnmodifiableListView<Interceptor> get interceptors =>
@@ -48,6 +50,7 @@ class SturdyHttp {
     HttpClientAdapter? customAdapter,
     Map<String, String>? proxy,
     bool inferContentType = true,
+    RetryBehavior retryBehavior = const NeverRetry(),
   }) : this._(
           dio: _configureDio(
             baseUrl: baseUrl,
@@ -59,6 +62,7 @@ class SturdyHttp {
           ),
           deserializer: deserializer,
           eventListener: eventListener,
+          retryBehavior: retryBehavior,
         );
 
   /// {@macro http_client}
@@ -66,9 +70,11 @@ class SturdyHttp {
     required Dio dio,
     required Deserializer deserializer,
     required SturdyHttpEventListener? eventListener,
+    required RetryBehavior retryBehavior,
   })  : _dio = dio,
         _deserializer = deserializer,
-        _eventListener = eventListener;
+        _eventListener = eventListener,
+        _retryBehavior = retryBehavior;
 
   /// {@macro http_client}
   SturdyHttp withBaseUrl(String baseUrl) {
@@ -81,6 +87,7 @@ class SturdyHttp {
         ..httpClientAdapter = _dio.httpClientAdapter,
       deserializer: _deserializer,
       eventListener: _eventListener,
+      retryBehavior: _retryBehavior,
     );
   }
 
@@ -122,93 +129,120 @@ class SturdyHttp {
   Future<_ResponsePayload<R>> _handleRequest<R, M>(
     NetworkRequest request,
   ) async {
-    late final NetworkResponse<R> resolvedResponse;
-    Response<Object?>? dioResponse;
-    try {
-      // By expecting `Object?` we allow for cases where an API will return
-      // nothing in success cases (e.g 204), but JSON in failure cases such as
-      // 422. If we specify `Json` here, Dio will map the null/empty case to
-      // an empty String, which is not a subtype of Json.
-      dioResponse = await _dio.request<Object?>(
-        request.path,
-        data: request.data.when(
-          empty: () => null,
-          json: (json) => json,
-          raw: (data) => data,
-        ),
-        queryParameters: request.queryParams,
-        options: request.options != null
-            ? request.options!.copyWith(method: request.type.name)
-            : Options(method: request.type.name),
-        cancelToken: request.cancelToken,
-        onReceiveProgress: request.onReceiveProgress,
-        onSendProgress: request.onSendProgress,
-      );
-      if (dioResponse.statusCode == 204) {
-        resolvedResponse = const NetworkResponse.okNoContent();
-      } else {
-        final data = dioResponse.data;
-        if (data == null || data is! R) {
-          String buildErrorMessage() {
-            final messageSuffix = data == null
-                // Disallow empty responses when status code is non-204
-                ? 'was null and status code was ${dioResponse!.statusCode}'
-                // Enforce that response data matches expected, otherwise we'll run into casting
-                // issues below
-                : 'was of type ${data.runtimeType} when it should have been of type $R';
-            return 'Request to ${request.path} was successful but response data $messageSuffix';
-          }
-
-          resolvedResponse = NetworkResponse.genericError(
-            message: buildErrorMessage(),
-            isConnectionIssue: false,
-          );
+    Future<(Response<Object?>?, NetworkResponse<R>)> send(
+      NetworkRequest request,
+    ) async {
+      late final NetworkResponse<R> resolvedResponse;
+      Response<Object?>? dioResponse;
+      try {
+        // By expecting `Object?` we allow for cases where an API will return
+        // nothing in success cases (e.g 204), but JSON in failure cases such as
+        // 422. If we specify `Json` here, Dio will map the null/empty case to
+        // an empty String, which is not a subtype of Json.
+        dioResponse = await _dio.request<Object?>(
+          request.path,
+          data: request.data.when(
+            empty: () => null,
+            json: (json) => json,
+            raw: (data) => data,
+          ),
+          queryParameters: request.queryParams,
+          options: request.options != null
+              ? request.options!.copyWith(method: request.type.name)
+              : Options(method: request.type.name),
+          cancelToken: request.cancelToken,
+          onReceiveProgress: request.onReceiveProgress,
+          onSendProgress: request.onSendProgress,
+        );
+        if (dioResponse.statusCode == 204) {
+          resolvedResponse = const NetworkResponse.okNoContent();
         } else {
-          resolvedResponse = NetworkResponse.ok(data as R);
+          final data = dioResponse.data;
+          if (data == null || data is! R) {
+            String buildErrorMessage() {
+              final messageSuffix = data == null
+                  // Disallow empty responses when status code is non-204
+                  ? 'was null and status code was ${dioResponse!.statusCode}'
+                  // Enforce that response data matches expected, otherwise we'll run into casting
+                  // issues below
+                  : 'was of type ${data.runtimeType} when it should have been of type $R';
+              return 'Request to ${request.path} was successful but response data $messageSuffix';
+            }
+
+            resolvedResponse = NetworkResponse.genericError(
+              message: buildErrorMessage(),
+              isConnectionIssue: false,
+            );
+          } else {
+            resolvedResponse = NetworkResponse.ok(data as R);
+          }
+        }
+      } on DioException catch (error) {
+        switch (error.response?.statusCode) {
+          case 401:
+            await _onEvent(SturdyHttpEvent.authFailure(error.requestOptions));
+            resolvedResponse = NetworkResponse.unauthorized(error);
+            break;
+          case 403:
+            resolvedResponse = NetworkResponse.forbidden(error);
+            break;
+          case 404:
+            resolvedResponse = NetworkResponse.notFound(error);
+            break;
+          case 422:
+            resolvedResponse = NetworkResponse.unprocessableEntity(
+              error: error,
+              response: error.response?.data as R,
+            );
+            break;
+          case 500:
+            resolvedResponse = NetworkResponse.serverError(error);
+            break;
+          case 503:
+            resolvedResponse = NetworkResponse.serviceUnavailable(error);
+            break;
+          default:
+            resolvedResponse = NetworkResponse.genericError(
+              message:
+                  'Unexpected status code ${error.response?.statusCode} returned for ${request.path}',
+              isConnectionIssue: error.isConnectionIssue(),
+              error: error,
+            );
         }
       }
-    } on DioException catch (error) {
-      switch (error.response?.statusCode) {
-        case 401:
-          await _onEvent(SturdyHttpEvent.authFailure(error.requestOptions));
-          resolvedResponse = NetworkResponse.unauthorized(error);
-          break;
-        case 403:
-          resolvedResponse = NetworkResponse.forbidden(error);
-          break;
-        case 404:
-          resolvedResponse = NetworkResponse.notFound(error);
-          break;
-        case 422:
-          resolvedResponse = NetworkResponse.unprocessableEntity(
-            error: error,
-            response: error.response?.data as R,
-          );
-          break;
-        case 500:
-          resolvedResponse = NetworkResponse.serverError(error);
-          break;
-        case 503:
-          resolvedResponse = NetworkResponse.serviceUnavailable(error);
-          break;
-        default:
-          resolvedResponse = NetworkResponse.genericError(
-            message:
-                'Unexpected status code ${error.response?.statusCode} returned for ${request.path}',
-            isConnectionIssue: error.isConnectionIssue(),
-            error: error,
-          );
-      }
+      return (dioResponse, resolvedResponse);
     }
-    if (resolvedResponse.isSuccess && request.shouldTriggerDataMutation) {
-      await _onEvent(
-        SturdyHttpEvent.mutativeRequestSuccess(dioResponse!.requestOptions),
+
+    RetryBehavior determineRetryBehavior() {
+      // The request's retry behavior takes precedence over the client's
+      final priority = [request.retryBehavior, _retryBehavior];
+      return priority.firstWhere(
+        (b) => b is! Unspecified,
+        orElse: () => NeverRetry(),
       );
     }
+
+    final retryBehavior = determineRetryBehavior();
+    var response = await send(request);
+    var retryCount = 0;
+    while (!response.$2.isSuccess &&
+        retryBehavior.shouldRetry(response.$1, retryCount)) {
+      // `retryBehavior` must be a `Retry`, otherwise we wouldn't be here.
+      await Future.delayed((retryBehavior as Retry).retryInterval);
+      retryCount++;
+      response = await send(request);
+    }
+
+    if (response.$2.isSuccess && request.shouldTriggerDataMutation) {
+      await _onEvent(
+        SturdyHttpEvent.mutativeRequestSuccess(response.$1!.requestOptions),
+      );
+    }
+
     return _ResponsePayload<R>(
       request: request,
-      dioResponse: dioResponse,
-      resolvedResponse: resolvedResponse,
+      dioResponse: response.$1,
+      resolvedResponse: response.$2,
     );
   }
 }

--- a/lib/src/sturdy_http.dart
+++ b/lib/src/sturdy_http.dart
@@ -120,7 +120,8 @@ class SturdyHttp {
   }
 
   Future<_ResponsePayload<R>> _handleRequest<R, M>(
-      NetworkRequest request) async {
+    NetworkRequest request,
+  ) async {
     late final NetworkResponse<R> resolvedResponse;
     Response<Object?>? dioResponse;
     try {
@@ -201,7 +202,8 @@ class SturdyHttp {
     }
     if (resolvedResponse.isSuccess && request.shouldTriggerDataMutation) {
       await _onEvent(
-          SturdyHttpEvent.mutativeRequestSuccess(dioResponse!.requestOptions));
+        SturdyHttpEvent.mutativeRequestSuccess(dioResponse!.requestOptions),
+      );
     }
     return _ResponsePayload<R>(
       request: request,

--- a/lib/src/sturdy_http_event_listener.freezed.dart
+++ b/lib/src/sturdy_http_event_listener.freezed.dart
@@ -12,7 +12,7 @@ part of 'sturdy_http_event_listener.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$SturdyHttpEvent {
@@ -108,11 +108,11 @@ class _$SturdyHttpEventCopyWithImpl<$Res, $Val extends SturdyHttpEvent>
 }
 
 /// @nodoc
-abstract class _$$_JsonDecodingErrorCopyWith<$Res>
+abstract class _$$JsonDecodingErrorImplCopyWith<$Res>
     implements $SturdyHttpEventCopyWith<$Res> {
-  factory _$$_JsonDecodingErrorCopyWith(_$_JsonDecodingError value,
-          $Res Function(_$_JsonDecodingError) then) =
-      __$$_JsonDecodingErrorCopyWithImpl<$Res>;
+  factory _$$JsonDecodingErrorImplCopyWith(_$JsonDecodingErrorImpl value,
+          $Res Function(_$JsonDecodingErrorImpl) then) =
+      __$$JsonDecodingErrorImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -120,11 +120,11 @@ abstract class _$$_JsonDecodingErrorCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_JsonDecodingErrorCopyWithImpl<$Res>
-    extends _$SturdyHttpEventCopyWithImpl<$Res, _$_JsonDecodingError>
-    implements _$$_JsonDecodingErrorCopyWith<$Res> {
-  __$$_JsonDecodingErrorCopyWithImpl(
-      _$_JsonDecodingError _value, $Res Function(_$_JsonDecodingError) _then)
+class __$$JsonDecodingErrorImplCopyWithImpl<$Res>
+    extends _$SturdyHttpEventCopyWithImpl<$Res, _$JsonDecodingErrorImpl>
+    implements _$$JsonDecodingErrorImplCopyWith<$Res> {
+  __$$JsonDecodingErrorImplCopyWithImpl(_$JsonDecodingErrorImpl _value,
+      $Res Function(_$JsonDecodingErrorImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -134,7 +134,7 @@ class __$$_JsonDecodingErrorCopyWithImpl<$Res>
     Object? exception = null,
     Object? stackTrace = freezed,
   }) {
-    return _then(_$_JsonDecodingError(
+    return _then(_$JsonDecodingErrorImpl(
       null == request
           ? _value.request
           : request // ignore: cast_nullable_to_non_nullable
@@ -153,8 +153,8 @@ class __$$_JsonDecodingErrorCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_JsonDecodingError implements _JsonDecodingError {
-  const _$_JsonDecodingError(this.request, this.exception, this.stackTrace);
+class _$JsonDecodingErrorImpl implements _JsonDecodingError {
+  const _$JsonDecodingErrorImpl(this.request, this.exception, this.stackTrace);
 
   @override
   final RequestOptions request;
@@ -169,10 +169,10 @@ class _$_JsonDecodingError implements _JsonDecodingError {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_JsonDecodingError &&
+            other is _$JsonDecodingErrorImpl &&
             (identical(other.request, request) || other.request == request) &&
             (identical(other.exception, exception) ||
                 other.exception == exception) &&
@@ -186,8 +186,8 @@ class _$_JsonDecodingError implements _JsonDecodingError {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_JsonDecodingErrorCopyWith<_$_JsonDecodingError> get copyWith =>
-      __$$_JsonDecodingErrorCopyWithImpl<_$_JsonDecodingError>(
+  _$$JsonDecodingErrorImplCopyWith<_$JsonDecodingErrorImpl> get copyWith =>
+      __$$JsonDecodingErrorImplCopyWithImpl<_$JsonDecodingErrorImpl>(
           this, _$identity);
 
   @override
@@ -270,7 +270,7 @@ abstract class _JsonDecodingError implements SturdyHttpEvent {
   const factory _JsonDecodingError(
       final RequestOptions request,
       final Exception exception,
-      final StackTrace? stackTrace) = _$_JsonDecodingError;
+      final StackTrace? stackTrace) = _$JsonDecodingErrorImpl;
 
   @override
   RequestOptions get request;
@@ -278,27 +278,27 @@ abstract class _JsonDecodingError implements SturdyHttpEvent {
   StackTrace? get stackTrace;
   @override
   @JsonKey(ignore: true)
-  _$$_JsonDecodingErrorCopyWith<_$_JsonDecodingError> get copyWith =>
+  _$$JsonDecodingErrorImplCopyWith<_$JsonDecodingErrorImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_AuthFailureCopyWith<$Res>
+abstract class _$$AuthFailureImplCopyWith<$Res>
     implements $SturdyHttpEventCopyWith<$Res> {
-  factory _$$_AuthFailureCopyWith(
-          _$_AuthFailure value, $Res Function(_$_AuthFailure) then) =
-      __$$_AuthFailureCopyWithImpl<$Res>;
+  factory _$$AuthFailureImplCopyWith(
+          _$AuthFailureImpl value, $Res Function(_$AuthFailureImpl) then) =
+      __$$AuthFailureImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({RequestOptions request});
 }
 
 /// @nodoc
-class __$$_AuthFailureCopyWithImpl<$Res>
-    extends _$SturdyHttpEventCopyWithImpl<$Res, _$_AuthFailure>
-    implements _$$_AuthFailureCopyWith<$Res> {
-  __$$_AuthFailureCopyWithImpl(
-      _$_AuthFailure _value, $Res Function(_$_AuthFailure) _then)
+class __$$AuthFailureImplCopyWithImpl<$Res>
+    extends _$SturdyHttpEventCopyWithImpl<$Res, _$AuthFailureImpl>
+    implements _$$AuthFailureImplCopyWith<$Res> {
+  __$$AuthFailureImplCopyWithImpl(
+      _$AuthFailureImpl _value, $Res Function(_$AuthFailureImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -306,7 +306,7 @@ class __$$_AuthFailureCopyWithImpl<$Res>
   $Res call({
     Object? request = null,
   }) {
-    return _then(_$_AuthFailure(
+    return _then(_$AuthFailureImpl(
       null == request
           ? _value.request
           : request // ignore: cast_nullable_to_non_nullable
@@ -317,8 +317,8 @@ class __$$_AuthFailureCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_AuthFailure implements _AuthFailure {
-  const _$_AuthFailure(this.request);
+class _$AuthFailureImpl implements _AuthFailure {
+  const _$AuthFailureImpl(this.request);
 
   @override
   final RequestOptions request;
@@ -329,10 +329,10 @@ class _$_AuthFailure implements _AuthFailure {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AuthFailure &&
+            other is _$AuthFailureImpl &&
             (identical(other.request, request) || other.request == request));
   }
 
@@ -342,8 +342,8 @@ class _$_AuthFailure implements _AuthFailure {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AuthFailureCopyWith<_$_AuthFailure> get copyWith =>
-      __$$_AuthFailureCopyWithImpl<_$_AuthFailure>(this, _$identity);
+  _$$AuthFailureImplCopyWith<_$AuthFailureImpl> get copyWith =>
+      __$$AuthFailureImplCopyWithImpl<_$AuthFailureImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -422,34 +422,35 @@ class _$_AuthFailure implements _AuthFailure {
 }
 
 abstract class _AuthFailure implements SturdyHttpEvent {
-  const factory _AuthFailure(final RequestOptions request) = _$_AuthFailure;
+  const factory _AuthFailure(final RequestOptions request) = _$AuthFailureImpl;
 
   @override
   RequestOptions get request;
   @override
   @JsonKey(ignore: true)
-  _$$_AuthFailureCopyWith<_$_AuthFailure> get copyWith =>
+  _$$AuthFailureImplCopyWith<_$AuthFailureImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_OnMutativeRequestSuccessCopyWith<$Res>
+abstract class _$$OnMutativeRequestSuccessImplCopyWith<$Res>
     implements $SturdyHttpEventCopyWith<$Res> {
-  factory _$$_OnMutativeRequestSuccessCopyWith(
-          _$_OnMutativeRequestSuccess value,
-          $Res Function(_$_OnMutativeRequestSuccess) then) =
-      __$$_OnMutativeRequestSuccessCopyWithImpl<$Res>;
+  factory _$$OnMutativeRequestSuccessImplCopyWith(
+          _$OnMutativeRequestSuccessImpl value,
+          $Res Function(_$OnMutativeRequestSuccessImpl) then) =
+      __$$OnMutativeRequestSuccessImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({RequestOptions request});
 }
 
 /// @nodoc
-class __$$_OnMutativeRequestSuccessCopyWithImpl<$Res>
-    extends _$SturdyHttpEventCopyWithImpl<$Res, _$_OnMutativeRequestSuccess>
-    implements _$$_OnMutativeRequestSuccessCopyWith<$Res> {
-  __$$_OnMutativeRequestSuccessCopyWithImpl(_$_OnMutativeRequestSuccess _value,
-      $Res Function(_$_OnMutativeRequestSuccess) _then)
+class __$$OnMutativeRequestSuccessImplCopyWithImpl<$Res>
+    extends _$SturdyHttpEventCopyWithImpl<$Res, _$OnMutativeRequestSuccessImpl>
+    implements _$$OnMutativeRequestSuccessImplCopyWith<$Res> {
+  __$$OnMutativeRequestSuccessImplCopyWithImpl(
+      _$OnMutativeRequestSuccessImpl _value,
+      $Res Function(_$OnMutativeRequestSuccessImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -457,7 +458,7 @@ class __$$_OnMutativeRequestSuccessCopyWithImpl<$Res>
   $Res call({
     Object? request = null,
   }) {
-    return _then(_$_OnMutativeRequestSuccess(
+    return _then(_$OnMutativeRequestSuccessImpl(
       null == request
           ? _value.request
           : request // ignore: cast_nullable_to_non_nullable
@@ -468,8 +469,8 @@ class __$$_OnMutativeRequestSuccessCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_OnMutativeRequestSuccess implements _OnMutativeRequestSuccess {
-  const _$_OnMutativeRequestSuccess(this.request);
+class _$OnMutativeRequestSuccessImpl implements _OnMutativeRequestSuccess {
+  const _$OnMutativeRequestSuccessImpl(this.request);
 
   @override
   final RequestOptions request;
@@ -480,10 +481,10 @@ class _$_OnMutativeRequestSuccess implements _OnMutativeRequestSuccess {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_OnMutativeRequestSuccess &&
+            other is _$OnMutativeRequestSuccessImpl &&
             (identical(other.request, request) || other.request == request));
   }
 
@@ -493,9 +494,9 @@ class _$_OnMutativeRequestSuccess implements _OnMutativeRequestSuccess {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_OnMutativeRequestSuccessCopyWith<_$_OnMutativeRequestSuccess>
-      get copyWith => __$$_OnMutativeRequestSuccessCopyWithImpl<
-          _$_OnMutativeRequestSuccess>(this, _$identity);
+  _$$OnMutativeRequestSuccessImplCopyWith<_$OnMutativeRequestSuccessImpl>
+      get copyWith => __$$OnMutativeRequestSuccessImplCopyWithImpl<
+          _$OnMutativeRequestSuccessImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -575,12 +576,12 @@ class _$_OnMutativeRequestSuccess implements _OnMutativeRequestSuccess {
 
 abstract class _OnMutativeRequestSuccess implements SturdyHttpEvent {
   const factory _OnMutativeRequestSuccess(final RequestOptions request) =
-      _$_OnMutativeRequestSuccess;
+      _$OnMutativeRequestSuccessImpl;
 
   @override
   RequestOptions get request;
   @override
   @JsonKey(ignore: true)
-  _$$_OnMutativeRequestSuccessCopyWith<_$_OnMutativeRequestSuccess>
+  _$$OnMutativeRequestSuccessImplCopyWith<_$OnMutativeRequestSuccessImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/test/src/deserializer_test.dart
+++ b/test/src/deserializer_test.dart
@@ -10,8 +10,7 @@ import 'sturdy_http_test.dart';
 
 void main() {
   group('BackgroundDeserializer', () {
-    test('it invokes onResponse on a non-main Isolate and sends result back',
-        () async {
+    test('it invokes onResponse on a non-main Isolate and sends result back', () async {
       onResponse(NetworkResponse<Json> response) {
         final isolateName = Isolate.current.debugName;
         // Hijack `Foo` to send over the `IsolateName` since
@@ -42,16 +41,18 @@ void main() {
       final responseTwo = NetworkResponse.ok(const Foo(message: '2').toJson());
       final subject = BackgroundDeserializer();
       final resultOne = await subject.deserialize(
-          response: responseOne, onResponse: onResponse);
+        response: responseOne,
+        onResponse: onResponse,
+      );
       final resultTwo = await subject.deserialize(
-          response: responseTwo, onResponse: onResponse);
+        response: responseTwo,
+        onResponse: onResponse,
+      );
       expect(resultOne.message, '1');
       expect(resultTwo.message, '2');
     });
 
-    test(
-        'it throws CheckedFromJsonExceptions when deserialization issues occur',
-        () async {
+    test('it throws CheckedFromJsonExceptions when deserialization issues occur', () async {
       onResponse(NetworkResponse<Json> response) {
         return response.maybeWhen(
           // Attempt to deserialize will fail because the response

--- a/test/src/deserializer_test.dart
+++ b/test/src/deserializer_test.dart
@@ -10,7 +10,8 @@ import 'sturdy_http_test.dart';
 
 void main() {
   group('BackgroundDeserializer', () {
-    test('it invokes onResponse on a non-main Isolate and sends result back', () async {
+    test('it invokes onResponse on a non-main Isolate and sends result back',
+        () async {
       onResponse(NetworkResponse<Json> response) {
         final isolateName = Isolate.current.debugName;
         // Hijack `Foo` to send over the `IsolateName` since
@@ -52,7 +53,9 @@ void main() {
       expect(resultTwo.message, '2');
     });
 
-    test('it throws CheckedFromJsonExceptions when deserialization issues occur', () async {
+    test(
+        'it throws CheckedFromJsonExceptions when deserialization issues occur',
+        () async {
       onResponse(NetworkResponse<Json> response) {
         return response.maybeWhen(
           // Attempt to deserialize will fail because the response

--- a/test/src/retry_behavior_test.dart
+++ b/test/src/retry_behavior_test.dart
@@ -1,0 +1,85 @@
+import 'package:dio/dio.dart';
+import 'package:sturdy_http/src/retry_behavior.dart';
+import 'package:test/test.dart' hide Retry;
+
+void main() {
+  group('RetryBehavior', () {
+    test('Unspecified never retries', () {
+      final unspecified = const Unspecified();
+
+      expect(
+        unspecified.shouldRetry(
+          Response(
+            requestOptions: RequestOptions(),
+            statusCode: defaultRetryStatusCodes.first,
+          ),
+          1,
+        ),
+        isFalse,
+      );
+    });
+    test('NeverRetry never retries', () {
+      final neverRetry = const NeverRetry();
+
+      expect(
+        neverRetry.shouldRetry(
+          Response(
+            requestOptions: RequestOptions(),
+            statusCode: defaultRetryStatusCodes.first,
+          ),
+          1,
+        ),
+        isFalse,
+      );
+    });
+    group('Retry', () {
+      test('maxRetries is respected', () {
+        final retry = const Retry(
+          maxRetries: 1,
+          retryInterval: Duration.zero,
+        );
+
+        expect(
+          retry.shouldRetry(
+            Response(
+              requestOptions: RequestOptions(),
+              statusCode: defaultRetryStatusCodes.first,
+            ),
+            0,
+          ),
+          isTrue,
+        );
+
+        expect(
+          retry.shouldRetry(
+            Response(
+              requestOptions: RequestOptions(),
+              statusCode: defaultRetryStatusCodes.first,
+            ),
+            1,
+          ),
+          isFalse,
+        );
+      });
+
+      test('retryClause is respected', () {
+        final retry = Retry(
+          maxRetries: 100,
+          retryInterval: Duration.zero,
+          retryClause: (r) => false,
+        );
+
+        expect(
+          retry.shouldRetry(
+            Response(
+              requestOptions: RequestOptions(),
+              statusCode: defaultRetryStatusCodes.first,
+            ),
+            1,
+          ),
+          isFalse,
+        );
+      });
+    });
+  });
+}

--- a/test/src/sturdy_http_test.dart
+++ b/test/src/sturdy_http_test.dart
@@ -75,7 +75,8 @@ void main() {
           interceptors: [
             _FakeInterceptor(
               onRequestInvoked: (options) {
-                contentType = options.headers[Headers.contentTypeHeader] as String?;
+                contentType =
+                    options.headers[Headers.contentTypeHeader] as String?;
               },
             ),
           ],
@@ -98,7 +99,8 @@ void main() {
           interceptors: [
             _FakeInterceptor(
               onRequestInvoked: (options) {
-                contentType = options.headers[Headers.contentTypeHeader] as String?;
+                contentType =
+                    options.headers[Headers.contentTypeHeader] as String?;
               },
             ),
           ],
@@ -133,7 +135,9 @@ void main() {
     });
 
     group('withBaseUrl', () {
-      test('it returns a new instance with correct baseUrl and pre-configured settings', () {
+      test(
+          'it returns a new instance with correct baseUrl and pre-configured settings',
+          () {
         final oldInstance = buildSubject(
           interceptors: [_FakeInterceptor()],
         );
@@ -298,12 +302,14 @@ void main() {
 
               group('when deserialization succeeds', () {
                 test('it returns parsed model', () async {
-                  final response = await buildSubject().execute<Json, Result<Foo, String>>(
+                  final response =
+                      await buildSubject().execute<Json, Result<Foo, String>>(
                     const GetRequest('/foo'),
                     onResponse: (response) {
                       return response.maybeWhen(
                         ok: (json) => Result.success(Foo.fromJson(json)),
-                        orElse: () => const Result.failure('Not expected: orElse'),
+                        orElse: () =>
+                            const Result.failure('Not expected: orElse'),
                       );
                     },
                   );
@@ -316,13 +322,17 @@ void main() {
               });
 
               group('when deserialization fails', () {
-                test('it emits a decodingError event and rethrows the Exception', () async {
-                  final request = buildSubject().execute<Json, Result<Foo, String>>(
+                test(
+                    'it emits a decodingError event and rethrows the Exception',
+                    () async {
+                  final request =
+                      buildSubject().execute<Json, Result<Foo, String>>(
                     const GetRequest('/not-foo'),
                     onResponse: (response) {
                       return response.maybeWhen(
                         ok: (json) => Result.success(Foo.fromJson(json)),
-                        orElse: () => const Result.failure('Not expected: orElse'),
+                        orElse: () =>
+                            const Result.failure('Not expected: orElse'),
                       );
                     },
                   );
@@ -352,7 +362,8 @@ void main() {
                   );
                 });
                 test('it returns okNoContent', () async {
-                  final response = await buildSubject().execute<void, Result<bool, String>>(
+                  final response =
+                      await buildSubject().execute<void, Result<bool, String>>(
                     const PostRequest(
                       '/foo',
                       data: NetworkRequestBody.empty(),
@@ -360,7 +371,8 @@ void main() {
                     onResponse: (response) {
                       return response.maybeWhen(
                         okNoContent: () => const Result.success(true),
-                        orElse: () => const Result.failure('Not expected: orElse'),
+                        orElse: () =>
+                            const Result.failure('Not expected: orElse'),
                       );
                     },
                   );
@@ -385,7 +397,8 @@ void main() {
                 test(
                   'it returns genericError and isConnectionIssue is false',
                   () async {
-                    final response = await buildSubject().execute<void, Result<bool, String>>(
+                    final response = await buildSubject()
+                        .execute<void, Result<bool, String>>(
                       const PostRequest(
                         '/foo',
                         data: NetworkRequestBody.empty(),
@@ -396,7 +409,8 @@ void main() {
                             expect(isConnectionIssue, isFalse);
                             return const Result.success(true);
                           },
-                          orElse: () => const Result.failure('Not expected: orElse'),
+                          orElse: () =>
+                              const Result.failure('Not expected: orElse'),
                         );
                       },
                     );
@@ -439,7 +453,9 @@ void main() {
                     );
                 });
 
-                test('it emits a MutativeRequestSuccess event with correct path', () async {
+                test(
+                    'it emits a MutativeRequestSuccess event with correct path',
+                    () async {
                   final subject = buildSubject();
                   await Future.wait([
                     subject.execute<Json, Result<String, String>>(
@@ -450,7 +466,8 @@ void main() {
                       onResponse: (response) {
                         return response.maybeWhen(
                           ok: (json) => Result.success(json['foo'] as String),
-                          orElse: () => const Result.failure('Not expected: orElse'),
+                          orElse: () =>
+                              const Result.failure('Not expected: orElse'),
                         );
                       },
                     ),
@@ -462,7 +479,8 @@ void main() {
                       onResponse: (response) {
                         return response.maybeWhen(
                           ok: (json) => Result.success(json['foo'] as String),
-                          orElse: () => const Result.failure('Not expected: orElse'),
+                          orElse: () =>
+                              const Result.failure('Not expected: orElse'),
                         );
                       },
                     ),
@@ -474,7 +492,8 @@ void main() {
                       onResponse: (response) {
                         return response.maybeWhen(
                           ok: (json) => Result.success(json['foo'] as String),
-                          orElse: () => const Result.failure('Not expected: orElse'),
+                          orElse: () =>
+                              const Result.failure('Not expected: orElse'),
                         );
                       },
                     ),
@@ -495,7 +514,8 @@ void main() {
                 });
               });
 
-              group('and the response has status codes other than 200 or 204', () {
+              group('and the response has status codes other than 200 or 204',
+                  () {
                 setUp(() {
                   charlatan
                     ..whenPost(
@@ -521,7 +541,8 @@ void main() {
                     );
                 });
 
-                test('it does not emit a MutativeRequestSuccess event', () async {
+                test('it does not emit a MutativeRequestSuccess event',
+                    () async {
                   final subject = buildSubject();
                   await Future.wait([
                     subject.execute<Json, Result<String, String>>(
@@ -532,7 +553,8 @@ void main() {
                       onResponse: (response) {
                         return response.maybeWhen(
                           ok: (json) => Result.success(json['foo'] as String),
-                          orElse: () => const Result.failure('Not expected: orElse'),
+                          orElse: () =>
+                              const Result.failure('Not expected: orElse'),
                         );
                       },
                     ),
@@ -544,7 +566,8 @@ void main() {
                       onResponse: (response) {
                         return response.maybeWhen(
                           ok: (json) => Result.success(json['foo'] as String),
-                          orElse: () => const Result.failure('Not expected: orElse'),
+                          orElse: () =>
+                              const Result.failure('Not expected: orElse'),
                         );
                       },
                     ),
@@ -556,7 +579,8 @@ void main() {
                       onResponse: (response) {
                         return response.maybeWhen(
                           ok: (json) => Result.success(json['foo'] as String),
-                          orElse: () => const Result.failure('Not expected: orElse'),
+                          orElse: () =>
+                              const Result.failure('Not expected: orElse'),
                         );
                       },
                     ),
@@ -590,8 +614,10 @@ void main() {
               setupErrorResponse(statusCode: 401);
             });
 
-            test('it emits an authFailure event and invokes unauthorized', () async {
-              final response = await buildSubject().execute<Json, Result<bool, String>>(
+            test('it emits an authFailure event and invokes unauthorized',
+                () async {
+              final response =
+                  await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeMap(
@@ -616,7 +642,8 @@ void main() {
             });
 
             test('it returns forbidden', () async {
-              final response = await buildSubject().execute<Json, Result<bool, String>>(
+              final response =
+                  await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(
@@ -639,7 +666,8 @@ void main() {
             });
 
             test('it returns notFound', () async {
-              final response = await buildSubject().execute<Json, Result<bool, String>>(
+              final response =
+                  await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(
@@ -665,11 +693,13 @@ void main() {
             });
 
             test('it returns unprocessableEntity', () async {
-              final response = await buildSubject().execute<Json, Result<bool, String>>(
+              final response =
+                  await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(
-                    unprocessableEntity: (error, response) => const Result.success(true),
+                    unprocessableEntity: (error, response) =>
+                        const Result.success(true),
                     orElse: () => const Result.failure('Not expected: orElse'),
                   );
                 },
@@ -688,7 +718,8 @@ void main() {
             });
 
             test('it returns serverError', () async {
-              final response = await buildSubject().execute<Json, Result<bool, String>>(
+              final response =
+                  await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(
@@ -711,7 +742,8 @@ void main() {
             });
 
             test('it returns service unavailable', () async {
-              final response = await buildSubject().execute<Json, Result<bool, String>>(
+              final response =
+                  await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(
@@ -734,11 +766,13 @@ void main() {
             });
 
             test('it returns genericError', () async {
-              final response = await buildSubject().execute<Json, Result<bool, String>>(
+              final response =
+                  await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(
-                    genericError: (message, _, error) => const Result.success(true),
+                    genericError: (message, _, error) =>
+                        const Result.success(true),
                     orElse: () => const Result.failure('Not expected: orElse'),
                   );
                 },
@@ -759,8 +793,10 @@ void main() {
               );
             });
 
-            test('it returns genericError and isConnectionIssue is true', () async {
-              final response = await buildSubject().execute<Json, Result<bool, String>>(
+            test('it returns genericError and isConnectionIssue is true',
+                () async {
+              final response =
+                  await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(
@@ -792,7 +828,8 @@ void main() {
                   },
                 );
 
-                final response = await buildSubject().execute<Json, Result<bool, String>>(
+                final response =
+                    await buildSubject().execute<Json, Result<bool, String>>(
                   const GetRequest(
                     defaultPath,
                     retryBehavior: rb.Retry(
@@ -805,7 +842,8 @@ void main() {
                       genericError: (_, __, ___) {
                         return const Result.success(true);
                       },
-                      orElse: () => const Result.failure('Not expected: orElse'),
+                      orElse: () =>
+                          const Result.failure('Not expected: orElse'),
                     );
                   },
                 );
@@ -833,7 +871,8 @@ void main() {
                   },
                 );
 
-                final response = await buildSubject().execute<Json, Result<bool, String>>(
+                final response =
+                    await buildSubject().execute<Json, Result<bool, String>>(
                   const GetRequest(
                     defaultPath,
                     retryBehavior: rb.NeverRetry(),
@@ -843,7 +882,8 @@ void main() {
                       genericError: (_, __, ___) {
                         return const Result.success(true);
                       },
-                      orElse: () => const Result.failure('Not expected: orElse'),
+                      orElse: () =>
+                          const Result.failure('Not expected: orElse'),
                     );
                   },
                 );
@@ -885,7 +925,8 @@ void main() {
                       genericError: (_, __, ___) {
                         return const Result.success(true);
                       },
-                      orElse: () => const Result.failure('Not expected: orElse'),
+                      orElse: () =>
+                          const Result.failure('Not expected: orElse'),
                     );
                   },
                 );
@@ -932,7 +973,8 @@ void main() {
                       genericError: (_, __, ___) {
                         return const Result.success(true);
                       },
-                      orElse: () => const Result.failure('Not expected: orElse'),
+                      orElse: () =>
+                          const Result.failure('Not expected: orElse'),
                     );
                   },
                 );

--- a/test/src/sturdy_http_test.dart
+++ b/test/src/sturdy_http_test.dart
@@ -71,10 +71,9 @@ void main() {
           interceptors: [
             _FakeInterceptor(
               onRequestInvoked: (options) {
-                contentType =
-                    options.headers[Headers.contentTypeHeader] as String?;
+                contentType = options.headers[Headers.contentTypeHeader] as String?;
               },
-            )
+            ),
           ],
         );
 
@@ -95,10 +94,9 @@ void main() {
           interceptors: [
             _FakeInterceptor(
               onRequestInvoked: (options) {
-                contentType =
-                    options.headers[Headers.contentTypeHeader] as String?;
+                contentType = options.headers[Headers.contentTypeHeader] as String?;
               },
-            )
+            ),
           ],
         );
 
@@ -131,9 +129,7 @@ void main() {
     });
 
     group('withBaseUrl', () {
-      test(
-          'it returns a new instance with correct baseUrl and pre-configured settings',
-          () {
+      test('it returns a new instance with correct baseUrl and pre-configured settings', () {
         final oldInstance = buildSubject(
           interceptors: [_FakeInterceptor()],
         );
@@ -298,14 +294,12 @@ void main() {
 
               group('when deserialization succeeds', () {
                 test('it returns parsed model', () async {
-                  final response =
-                      await buildSubject().execute<Json, Result<Foo, String>>(
+                  final response = await buildSubject().execute<Json, Result<Foo, String>>(
                     const GetRequest('/foo'),
                     onResponse: (response) {
                       return response.maybeWhen(
                         ok: (json) => Result.success(Foo.fromJson(json)),
-                        orElse: () =>
-                            const Result.failure('Not expected: orElse'),
+                        orElse: () => const Result.failure('Not expected: orElse'),
                       );
                     },
                   );
@@ -318,17 +312,13 @@ void main() {
               });
 
               group('when deserialization fails', () {
-                test(
-                    'it emits a decodingError event and rethrows the Exception',
-                    () async {
-                  final request =
-                      buildSubject().execute<Json, Result<Foo, String>>(
+                test('it emits a decodingError event and rethrows the Exception', () async {
+                  final request = buildSubject().execute<Json, Result<Foo, String>>(
                     const GetRequest('/not-foo'),
                     onResponse: (response) {
                       return response.maybeWhen(
                         ok: (json) => Result.success(Foo.fromJson(json)),
-                        orElse: () =>
-                            const Result.failure('Not expected: orElse'),
+                        orElse: () => const Result.failure('Not expected: orElse'),
                       );
                     },
                   );
@@ -358,8 +348,7 @@ void main() {
                   );
                 });
                 test('it returns okNoContent', () async {
-                  final response =
-                      await buildSubject().execute<void, Result<bool, String>>(
+                  final response = await buildSubject().execute<void, Result<bool, String>>(
                     const PostRequest(
                       '/foo',
                       data: NetworkRequestBody.empty(),
@@ -367,8 +356,7 @@ void main() {
                     onResponse: (response) {
                       return response.maybeWhen(
                         okNoContent: () => const Result.success(true),
-                        orElse: () =>
-                            const Result.failure('Not expected: orElse'),
+                        orElse: () => const Result.failure('Not expected: orElse'),
                       );
                     },
                   );
@@ -393,8 +381,7 @@ void main() {
                 test(
                   'it returns genericError and isConnectionIssue is false',
                   () async {
-                    final response = await buildSubject()
-                        .execute<void, Result<bool, String>>(
+                    final response = await buildSubject().execute<void, Result<bool, String>>(
                       const PostRequest(
                         '/foo',
                         data: NetworkRequestBody.empty(),
@@ -405,8 +392,7 @@ void main() {
                             expect(isConnectionIssue, isFalse);
                             return const Result.success(true);
                           },
-                          orElse: () =>
-                              const Result.failure('Not expected: orElse'),
+                          orElse: () => const Result.failure('Not expected: orElse'),
                         );
                       },
                     );
@@ -449,9 +435,7 @@ void main() {
                     );
                 });
 
-                test(
-                    'it emits a MutativeRequestSuccess event with correct path',
-                    () async {
+                test('it emits a MutativeRequestSuccess event with correct path', () async {
                   final subject = buildSubject();
                   await Future.wait([
                     subject.execute<Json, Result<String, String>>(
@@ -462,8 +446,7 @@ void main() {
                       onResponse: (response) {
                         return response.maybeWhen(
                           ok: (json) => Result.success(json['foo'] as String),
-                          orElse: () =>
-                              const Result.failure('Not expected: orElse'),
+                          orElse: () => const Result.failure('Not expected: orElse'),
                         );
                       },
                     ),
@@ -475,8 +458,7 @@ void main() {
                       onResponse: (response) {
                         return response.maybeWhen(
                           ok: (json) => Result.success(json['foo'] as String),
-                          orElse: () =>
-                              const Result.failure('Not expected: orElse'),
+                          orElse: () => const Result.failure('Not expected: orElse'),
                         );
                       },
                     ),
@@ -488,11 +470,10 @@ void main() {
                       onResponse: (response) {
                         return response.maybeWhen(
                           ok: (json) => Result.success(json['foo'] as String),
-                          orElse: () =>
-                              const Result.failure('Not expected: orElse'),
+                          orElse: () => const Result.failure('Not expected: orElse'),
                         );
                       },
-                    )
+                    ),
                   ]);
 
                   expect(
@@ -510,8 +491,7 @@ void main() {
                 });
               });
 
-              group('and the response has status codes other than 200 or 204',
-                  () {
+              group('and the response has status codes other than 200 or 204', () {
                 setUp(() {
                   charlatan
                     ..whenPost(
@@ -537,8 +517,7 @@ void main() {
                     );
                 });
 
-                test('it does not emit a MutativeRequestSuccess event',
-                    () async {
+                test('it does not emit a MutativeRequestSuccess event', () async {
                   final subject = buildSubject();
                   await Future.wait([
                     subject.execute<Json, Result<String, String>>(
@@ -549,8 +528,7 @@ void main() {
                       onResponse: (response) {
                         return response.maybeWhen(
                           ok: (json) => Result.success(json['foo'] as String),
-                          orElse: () =>
-                              const Result.failure('Not expected: orElse'),
+                          orElse: () => const Result.failure('Not expected: orElse'),
                         );
                       },
                     ),
@@ -562,8 +540,7 @@ void main() {
                       onResponse: (response) {
                         return response.maybeWhen(
                           ok: (json) => Result.success(json['foo'] as String),
-                          orElse: () =>
-                              const Result.failure('Not expected: orElse'),
+                          orElse: () => const Result.failure('Not expected: orElse'),
                         );
                       },
                     ),
@@ -575,11 +552,10 @@ void main() {
                       onResponse: (response) {
                         return response.maybeWhen(
                           ok: (json) => Result.success(json['foo'] as String),
-                          orElse: () =>
-                              const Result.failure('Not expected: orElse'),
+                          orElse: () => const Result.failure('Not expected: orElse'),
                         );
                       },
-                    )
+                    ),
                   ]);
 
                   expect(mutativeRequestSuccessRequests.isEmpty, true);
@@ -610,10 +586,8 @@ void main() {
               setupErrorResponse(statusCode: 401);
             });
 
-            test('it emits an authFailure event and invokes unauthorized',
-                () async {
-              final response =
-                  await buildSubject().execute<Json, Result<bool, String>>(
+            test('it emits an authFailure event and invokes unauthorized', () async {
+              final response = await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeMap(
@@ -638,8 +612,7 @@ void main() {
             });
 
             test('it returns forbidden', () async {
-              final response =
-                  await buildSubject().execute<Json, Result<bool, String>>(
+              final response = await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(
@@ -662,8 +635,7 @@ void main() {
             });
 
             test('it returns notFound', () async {
-              final response =
-                  await buildSubject().execute<Json, Result<bool, String>>(
+              final response = await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(
@@ -689,13 +661,11 @@ void main() {
             });
 
             test('it returns unprocessableEntity', () async {
-              final response =
-                  await buildSubject().execute<Json, Result<bool, String>>(
+              final response = await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(
-                    unprocessableEntity: (error, response) =>
-                        const Result.success(true),
+                    unprocessableEntity: (error, response) => const Result.success(true),
                     orElse: () => const Result.failure('Not expected: orElse'),
                   );
                 },
@@ -714,8 +684,7 @@ void main() {
             });
 
             test('it returns serverError', () async {
-              final response =
-                  await buildSubject().execute<Json, Result<bool, String>>(
+              final response = await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(
@@ -738,8 +707,7 @@ void main() {
             });
 
             test('it returns service unavailable', () async {
-              final response =
-                  await buildSubject().execute<Json, Result<bool, String>>(
+              final response = await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(
@@ -762,13 +730,11 @@ void main() {
             });
 
             test('it returns genericError', () async {
-              final response =
-                  await buildSubject().execute<Json, Result<bool, String>>(
+              final response = await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(
-                    genericError: (message, _, error) =>
-                        const Result.success(true),
+                    genericError: (message, _, error) => const Result.success(true),
                     orElse: () => const Result.failure('Not expected: orElse'),
                   );
                 },
@@ -789,10 +755,8 @@ void main() {
               );
             });
 
-            test('it returns genericError and isConnectionIssue is true',
-                () async {
-              final response =
-                  await buildSubject().execute<Json, Result<bool, String>>(
+            test('it returns genericError and isConnectionIssue is true', () async {
+              final response = await buildSubject().execute<Json, Result<bool, String>>(
                 const GetRequest(defaultPath),
                 onResponse: (response) {
                   return response.maybeWhen(

--- a/test/src/sturdy_http_test.dart
+++ b/test/src/sturdy_http_test.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:charlatan/charlatan.dart';
 import 'package:dio/dio.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:sturdy_http/src/retry_behavior.dart' as rb;
+import 'package:sturdy_http/src/retry_behavior.dart';
 import 'package:sturdy_http/sturdy_http.dart';
 import 'package:test/test.dart';
 
@@ -40,6 +42,7 @@ void main() {
       List<Interceptor> interceptors = const [],
       Map<String, String>? proxy,
       bool inferContentType = false,
+      rb.RetryBehavior retryBehavior = const rb.NeverRetry(),
     }) {
       return SturdyHttp(
         baseUrl: baseUrl,
@@ -48,6 +51,7 @@ void main() {
         interceptors: interceptors,
         proxy: proxy,
         inferContentType: inferContentType,
+        retryBehavior: retryBehavior,
       );
     }
 
@@ -773,6 +777,175 @@ void main() {
                 success: (s) => expect(s, isTrue),
                 failure: fail,
               );
+            });
+          });
+
+          group('RetryBehavior', () {
+            group('when retry behavior is Retry', () {
+              test('it retries maxRetries times', () async {
+                var requestCount = 0;
+                charlatan.whenGet(
+                  '/foo',
+                  (request) {
+                    requestCount++;
+                    return CharlatanHttpResponse(statusCode: 522);
+                  },
+                );
+
+                final response = await buildSubject().execute<Json, Result<bool, String>>(
+                  const GetRequest(
+                    defaultPath,
+                    retryBehavior: rb.Retry(
+                      maxRetries: 3,
+                      retryInterval: Duration(milliseconds: 100),
+                    ),
+                  ),
+                  onResponse: (response) {
+                    return response.maybeWhen(
+                      genericError: (_, __, ___) {
+                        return const Result.success(true);
+                      },
+                      orElse: () => const Result.failure('Not expected: orElse'),
+                    );
+                  },
+                );
+
+                expect(
+                  response.when(
+                    success: (s) => s,
+                    failure: fail,
+                  ),
+                  isTrue,
+                );
+                // maxRetries + 1
+                expect(requestCount, 4);
+              });
+            });
+
+            group('when retry behavior is NeverRetry', () {
+              test('it does not retry', () async {
+                var requestCount = 0;
+                charlatan.whenGet(
+                  '/foo',
+                  (request) {
+                    requestCount++;
+                    return CharlatanHttpResponse(statusCode: 522);
+                  },
+                );
+
+                final response = await buildSubject().execute<Json, Result<bool, String>>(
+                  const GetRequest(
+                    defaultPath,
+                    retryBehavior: rb.NeverRetry(),
+                  ),
+                  onResponse: (response) {
+                    return response.maybeWhen(
+                      genericError: (_, __, ___) {
+                        return const Result.success(true);
+                      },
+                      orElse: () => const Result.failure('Not expected: orElse'),
+                    );
+                  },
+                );
+
+                expect(
+                  response.when(
+                    success: (s) => s,
+                    failure: fail,
+                  ),
+                  isTrue,
+                );
+                expect(requestCount, 1);
+              });
+            });
+
+            group('RetryBehavior priority', () {
+              test('it prefers local RetryBehavior to global', () async {
+                var requestCount = 0;
+                charlatan.whenGet(
+                  '/foo',
+                  (request) {
+                    requestCount++;
+                    return CharlatanHttpResponse(statusCode: 522);
+                  },
+                );
+
+                final response = await buildSubject(
+                  retryBehavior: rb.NeverRetry(),
+                ).execute<Json, Result<bool, String>>(
+                  const GetRequest(
+                    defaultPath,
+                    retryBehavior: rb.Retry(
+                      maxRetries: 2,
+                      retryInterval: Duration(milliseconds: 100),
+                    ),
+                  ),
+                  onResponse: (response) {
+                    return response.maybeWhen(
+                      genericError: (_, __, ___) {
+                        return const Result.success(true);
+                      },
+                      orElse: () => const Result.failure('Not expected: orElse'),
+                    );
+                  },
+                );
+
+                expect(
+                  response.when(
+                    success: (s) => s,
+                    failure: fail,
+                  ),
+                  isTrue,
+                );
+                expect(requestCount, 3);
+              });
+            });
+
+            group('RetryBehavior priority', () {
+              test('it allows overriding retryClause', () async {
+                var requestCount = 0;
+                final statusCode = defaultRetryStatusCodes.first;
+                charlatan.whenGet(
+                  '/foo',
+                  (request) {
+                    requestCount++;
+                    return CharlatanHttpResponse(statusCode: statusCode);
+                  },
+                );
+
+                final response = await buildSubject(
+                  retryBehavior: rb.NeverRetry(),
+                ).execute<Json, Result<bool, String>>(
+                  GetRequest(
+                    defaultPath,
+                    retryBehavior: rb.Retry(
+                      maxRetries: 2,
+                      retryInterval: Duration(milliseconds: 100),
+                      retryClause: (r) {
+                        // Body will be `null`; essentially disallow retrying
+                        return r != null;
+                      },
+                    ),
+                  ),
+                  onResponse: (response) {
+                    return response.maybeWhen(
+                      genericError: (_, __, ___) {
+                        return const Result.success(true);
+                      },
+                      orElse: () => const Result.failure('Not expected: orElse'),
+                    );
+                  },
+                );
+
+                expect(
+                  response.when(
+                    success: (s) => s,
+                    failure: fail,
+                  ),
+                  isTrue,
+                );
+                expect(requestCount, 1);
+              });
             });
           });
         });

--- a/test/src/sturdy_http_test.freezed.dart
+++ b/test/src/sturdy_http_test.freezed.dart
@@ -12,7 +12,7 @@ part of 'sturdy_http_test.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$Result<S, F> {
@@ -75,20 +75,20 @@ class _$ResultCopyWithImpl<S, F, $Res, $Val extends Result<S, F>>
 }
 
 /// @nodoc
-abstract class _$$_SuccessCopyWith<S, F, $Res> {
-  factory _$$_SuccessCopyWith(
-          _$_Success<S, F> value, $Res Function(_$_Success<S, F>) then) =
-      __$$_SuccessCopyWithImpl<S, F, $Res>;
+abstract class _$$SuccessImplCopyWith<S, F, $Res> {
+  factory _$$SuccessImplCopyWith(
+          _$SuccessImpl<S, F> value, $Res Function(_$SuccessImpl<S, F>) then) =
+      __$$SuccessImplCopyWithImpl<S, F, $Res>;
   @useResult
   $Res call({S success});
 }
 
 /// @nodoc
-class __$$_SuccessCopyWithImpl<S, F, $Res>
-    extends _$ResultCopyWithImpl<S, F, $Res, _$_Success<S, F>>
-    implements _$$_SuccessCopyWith<S, F, $Res> {
-  __$$_SuccessCopyWithImpl(
-      _$_Success<S, F> _value, $Res Function(_$_Success<S, F>) _then)
+class __$$SuccessImplCopyWithImpl<S, F, $Res>
+    extends _$ResultCopyWithImpl<S, F, $Res, _$SuccessImpl<S, F>>
+    implements _$$SuccessImplCopyWith<S, F, $Res> {
+  __$$SuccessImplCopyWithImpl(
+      _$SuccessImpl<S, F> _value, $Res Function(_$SuccessImpl<S, F>) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -96,7 +96,7 @@ class __$$_SuccessCopyWithImpl<S, F, $Res>
   $Res call({
     Object? success = freezed,
   }) {
-    return _then(_$_Success<S, F>(
+    return _then(_$SuccessImpl<S, F>(
       freezed == success
           ? _value.success
           : success // ignore: cast_nullable_to_non_nullable
@@ -107,8 +107,8 @@ class __$$_SuccessCopyWithImpl<S, F, $Res>
 
 /// @nodoc
 
-class _$_Success<S, F> implements _Success<S, F> {
-  const _$_Success(this.success);
+class _$SuccessImpl<S, F> implements _Success<S, F> {
+  const _$SuccessImpl(this.success);
 
   @override
   final S success;
@@ -119,10 +119,10 @@ class _$_Success<S, F> implements _Success<S, F> {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Success<S, F> &&
+            other is _$SuccessImpl<S, F> &&
             const DeepCollectionEquality().equals(other.success, success));
   }
 
@@ -133,8 +133,8 @@ class _$_Success<S, F> implements _Success<S, F> {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_SuccessCopyWith<S, F, _$_Success<S, F>> get copyWith =>
-      __$$_SuccessCopyWithImpl<S, F, _$_Success<S, F>>(this, _$identity);
+  _$$SuccessImplCopyWith<S, F, _$SuccessImpl<S, F>> get copyWith =>
+      __$$SuccessImplCopyWithImpl<S, F, _$SuccessImpl<S, F>>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -200,29 +200,29 @@ class _$_Success<S, F> implements _Success<S, F> {
 }
 
 abstract class _Success<S, F> implements Result<S, F> {
-  const factory _Success(final S success) = _$_Success<S, F>;
+  const factory _Success(final S success) = _$SuccessImpl<S, F>;
 
   S get success;
   @JsonKey(ignore: true)
-  _$$_SuccessCopyWith<S, F, _$_Success<S, F>> get copyWith =>
+  _$$SuccessImplCopyWith<S, F, _$SuccessImpl<S, F>> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-abstract class _$$_FailureCopyWith<S, F, $Res> {
-  factory _$$_FailureCopyWith(
-          _$_Failure<S, F> value, $Res Function(_$_Failure<S, F>) then) =
-      __$$_FailureCopyWithImpl<S, F, $Res>;
+abstract class _$$FailureImplCopyWith<S, F, $Res> {
+  factory _$$FailureImplCopyWith(
+          _$FailureImpl<S, F> value, $Res Function(_$FailureImpl<S, F>) then) =
+      __$$FailureImplCopyWithImpl<S, F, $Res>;
   @useResult
   $Res call({F failure});
 }
 
 /// @nodoc
-class __$$_FailureCopyWithImpl<S, F, $Res>
-    extends _$ResultCopyWithImpl<S, F, $Res, _$_Failure<S, F>>
-    implements _$$_FailureCopyWith<S, F, $Res> {
-  __$$_FailureCopyWithImpl(
-      _$_Failure<S, F> _value, $Res Function(_$_Failure<S, F>) _then)
+class __$$FailureImplCopyWithImpl<S, F, $Res>
+    extends _$ResultCopyWithImpl<S, F, $Res, _$FailureImpl<S, F>>
+    implements _$$FailureImplCopyWith<S, F, $Res> {
+  __$$FailureImplCopyWithImpl(
+      _$FailureImpl<S, F> _value, $Res Function(_$FailureImpl<S, F>) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -230,7 +230,7 @@ class __$$_FailureCopyWithImpl<S, F, $Res>
   $Res call({
     Object? failure = freezed,
   }) {
-    return _then(_$_Failure<S, F>(
+    return _then(_$FailureImpl<S, F>(
       freezed == failure
           ? _value.failure
           : failure // ignore: cast_nullable_to_non_nullable
@@ -241,8 +241,8 @@ class __$$_FailureCopyWithImpl<S, F, $Res>
 
 /// @nodoc
 
-class _$_Failure<S, F> implements _Failure<S, F> {
-  const _$_Failure(this.failure);
+class _$FailureImpl<S, F> implements _Failure<S, F> {
+  const _$FailureImpl(this.failure);
 
   @override
   final F failure;
@@ -253,10 +253,10 @@ class _$_Failure<S, F> implements _Failure<S, F> {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Failure<S, F> &&
+            other is _$FailureImpl<S, F> &&
             const DeepCollectionEquality().equals(other.failure, failure));
   }
 
@@ -267,8 +267,8 @@ class _$_Failure<S, F> implements _Failure<S, F> {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_FailureCopyWith<S, F, _$_Failure<S, F>> get copyWith =>
-      __$$_FailureCopyWithImpl<S, F, _$_Failure<S, F>>(this, _$identity);
+  _$$FailureImplCopyWith<S, F, _$FailureImpl<S, F>> get copyWith =>
+      __$$FailureImplCopyWithImpl<S, F, _$FailureImpl<S, F>>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -334,11 +334,11 @@ class _$_Failure<S, F> implements _Failure<S, F> {
 }
 
 abstract class _Failure<S, F> implements Result<S, F> {
-  const factory _Failure(final F failure) = _$_Failure<S, F>;
+  const factory _Failure(final F failure) = _$FailureImpl<S, F>;
 
   F get failure;
   @JsonKey(ignore: true)
-  _$$_FailureCopyWith<S, F, _$_Failure<S, F>> get copyWith =>
+  _$$FailureImplCopyWith<S, F, _$FailureImpl<S, F>> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
@@ -387,18 +387,18 @@ class _$FooCopyWithImpl<$Res, $Val extends Foo> implements $FooCopyWith<$Res> {
 }
 
 /// @nodoc
-abstract class _$$_FooCopyWith<$Res> implements $FooCopyWith<$Res> {
-  factory _$$_FooCopyWith(_$_Foo value, $Res Function(_$_Foo) then) =
-      __$$_FooCopyWithImpl<$Res>;
+abstract class _$$FooImplCopyWith<$Res> implements $FooCopyWith<$Res> {
+  factory _$$FooImplCopyWith(_$FooImpl value, $Res Function(_$FooImpl) then) =
+      __$$FooImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String message});
 }
 
 /// @nodoc
-class __$$_FooCopyWithImpl<$Res> extends _$FooCopyWithImpl<$Res, _$_Foo>
-    implements _$$_FooCopyWith<$Res> {
-  __$$_FooCopyWithImpl(_$_Foo _value, $Res Function(_$_Foo) _then)
+class __$$FooImplCopyWithImpl<$Res> extends _$FooCopyWithImpl<$Res, _$FooImpl>
+    implements _$$FooImplCopyWith<$Res> {
+  __$$FooImplCopyWithImpl(_$FooImpl _value, $Res Function(_$FooImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -406,7 +406,7 @@ class __$$_FooCopyWithImpl<$Res> extends _$FooCopyWithImpl<$Res, _$_Foo>
   $Res call({
     Object? message = null,
   }) {
-    return _then(_$_Foo(
+    return _then(_$FooImpl(
       message: null == message
           ? _value.message
           : message // ignore: cast_nullable_to_non_nullable
@@ -417,10 +417,11 @@ class __$$_FooCopyWithImpl<$Res> extends _$FooCopyWithImpl<$Res, _$_Foo>
 
 /// @nodoc
 @JsonSerializable()
-class _$_Foo implements _Foo {
-  const _$_Foo({required this.message});
+class _$FooImpl implements _Foo {
+  const _$FooImpl({required this.message});
 
-  factory _$_Foo.fromJson(Map<String, dynamic> json) => _$$_FooFromJson(json);
+  factory _$FooImpl.fromJson(Map<String, dynamic> json) =>
+      _$$FooImplFromJson(json);
 
   @override
   final String message;
@@ -431,10 +432,10 @@ class _$_Foo implements _Foo {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_Foo &&
+            other is _$FooImpl &&
             (identical(other.message, message) || other.message == message));
   }
 
@@ -445,27 +446,28 @@ class _$_Foo implements _Foo {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_FooCopyWith<_$_Foo> get copyWith =>
-      __$$_FooCopyWithImpl<_$_Foo>(this, _$identity);
+  _$$FooImplCopyWith<_$FooImpl> get copyWith =>
+      __$$FooImplCopyWithImpl<_$FooImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_FooToJson(
+    return _$$FooImplToJson(
       this,
     );
   }
 }
 
 abstract class _Foo implements Foo {
-  const factory _Foo({required final String message}) = _$_Foo;
+  const factory _Foo({required final String message}) = _$FooImpl;
 
-  factory _Foo.fromJson(Map<String, dynamic> json) = _$_Foo.fromJson;
+  factory _Foo.fromJson(Map<String, dynamic> json) = _$FooImpl.fromJson;
 
   @override
   String get message;
   @override
   @JsonKey(ignore: true)
-  _$$_FooCopyWith<_$_Foo> get copyWith => throw _privateConstructorUsedError;
+  _$$FooImplCopyWith<_$FooImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 NotFoo _$NotFooFromJson(Map<String, dynamic> json) {
@@ -514,19 +516,21 @@ class _$NotFooCopyWithImpl<$Res, $Val extends NotFoo>
 }
 
 /// @nodoc
-abstract class _$$_NotFooCopyWith<$Res> implements $NotFooCopyWith<$Res> {
-  factory _$$_NotFooCopyWith(_$_NotFoo value, $Res Function(_$_NotFoo) then) =
-      __$$_NotFooCopyWithImpl<$Res>;
+abstract class _$$NotFooImplCopyWith<$Res> implements $NotFooCopyWith<$Res> {
+  factory _$$NotFooImplCopyWith(
+          _$NotFooImpl value, $Res Function(_$NotFooImpl) then) =
+      __$$NotFooImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String notMessage});
 }
 
 /// @nodoc
-class __$$_NotFooCopyWithImpl<$Res>
-    extends _$NotFooCopyWithImpl<$Res, _$_NotFoo>
-    implements _$$_NotFooCopyWith<$Res> {
-  __$$_NotFooCopyWithImpl(_$_NotFoo _value, $Res Function(_$_NotFoo) _then)
+class __$$NotFooImplCopyWithImpl<$Res>
+    extends _$NotFooCopyWithImpl<$Res, _$NotFooImpl>
+    implements _$$NotFooImplCopyWith<$Res> {
+  __$$NotFooImplCopyWithImpl(
+      _$NotFooImpl _value, $Res Function(_$NotFooImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -534,7 +538,7 @@ class __$$_NotFooCopyWithImpl<$Res>
   $Res call({
     Object? notMessage = null,
   }) {
-    return _then(_$_NotFoo(
+    return _then(_$NotFooImpl(
       notMessage: null == notMessage
           ? _value.notMessage
           : notMessage // ignore: cast_nullable_to_non_nullable
@@ -545,11 +549,11 @@ class __$$_NotFooCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_NotFoo implements _NotFoo {
-  const _$_NotFoo({required this.notMessage});
+class _$NotFooImpl implements _NotFoo {
+  const _$NotFooImpl({required this.notMessage});
 
-  factory _$_NotFoo.fromJson(Map<String, dynamic> json) =>
-      _$$_NotFooFromJson(json);
+  factory _$NotFooImpl.fromJson(Map<String, dynamic> json) =>
+      _$$NotFooImplFromJson(json);
 
   @override
   final String notMessage;
@@ -560,10 +564,10 @@ class _$_NotFoo implements _NotFoo {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_NotFoo &&
+            other is _$NotFooImpl &&
             (identical(other.notMessage, notMessage) ||
                 other.notMessage == notMessage));
   }
@@ -575,26 +579,26 @@ class _$_NotFoo implements _NotFoo {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_NotFooCopyWith<_$_NotFoo> get copyWith =>
-      __$$_NotFooCopyWithImpl<_$_NotFoo>(this, _$identity);
+  _$$NotFooImplCopyWith<_$NotFooImpl> get copyWith =>
+      __$$NotFooImplCopyWithImpl<_$NotFooImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_NotFooToJson(
+    return _$$NotFooImplToJson(
       this,
     );
   }
 }
 
 abstract class _NotFoo implements NotFoo {
-  const factory _NotFoo({required final String notMessage}) = _$_NotFoo;
+  const factory _NotFoo({required final String notMessage}) = _$NotFooImpl;
 
-  factory _NotFoo.fromJson(Map<String, dynamic> json) = _$_NotFoo.fromJson;
+  factory _NotFoo.fromJson(Map<String, dynamic> json) = _$NotFooImpl.fromJson;
 
   @override
   String get notMessage;
   @override
   @JsonKey(ignore: true)
-  _$$_NotFooCopyWith<_$_NotFoo> get copyWith =>
+  _$$NotFooImplCopyWith<_$NotFooImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/test/src/sturdy_http_test.g.dart
+++ b/test/src/sturdy_http_test.g.dart
@@ -6,26 +6,26 @@ part of 'sturdy_http_test.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_Foo _$$_FooFromJson(Map<String, dynamic> json) => $checkedCreate(
-      r'_$_Foo',
+_$FooImpl _$$FooImplFromJson(Map<String, dynamic> json) => $checkedCreate(
+      r'_$FooImpl',
       json,
       ($checkedConvert) {
-        final val = _$_Foo(
+        final val = _$FooImpl(
           message: $checkedConvert('message', (v) => v as String),
         );
         return val;
       },
     );
 
-Map<String, dynamic> _$$_FooToJson(_$_Foo instance) => <String, dynamic>{
+Map<String, dynamic> _$$FooImplToJson(_$FooImpl instance) => <String, dynamic>{
       'message': instance.message,
     };
 
-_$_NotFoo _$$_NotFooFromJson(Map<String, dynamic> json) => $checkedCreate(
-      r'_$_NotFoo',
+_$NotFooImpl _$$NotFooImplFromJson(Map<String, dynamic> json) => $checkedCreate(
+      r'_$NotFooImpl',
       json,
       ($checkedConvert) {
-        final val = _$_NotFoo(
+        final val = _$NotFooImpl(
           notMessage: $checkedConvert('not_message', (v) => v as String),
         );
         return val;
@@ -33,6 +33,7 @@ _$_NotFoo _$$_NotFooFromJson(Map<String, dynamic> json) => $checkedCreate(
       fieldKeyMap: const {'notMessage': 'not_message'},
     );
 
-Map<String, dynamic> _$$_NotFooToJson(_$_NotFoo instance) => <String, dynamic>{
+Map<String, dynamic> _$$NotFooImplToJson(_$NotFooImpl instance) =>
+    <String, dynamic>{
       'not_message': instance.notMessage,
     };


### PR DESCRIPTION
### 📰 Summary of changes
<!-- Feel free to delete this section if it doesn't apply -->
> What is the new functionality added in this PR?

This PR adds support for retrying failed network requests. In short, the following is now possible:
- Specifying a `RetryBehavior` "globally" for any request made by the `SturdyHttp` instance
- Specifying a `RetryBehavior` "locally" for a single request, which takes precedence over the `RetryBehavior` of the `SturdyHttp` instance
- Relying on the default retry logic provided by `defaultRetryClause`
- Specifying custom retry logic

**Notable:** This implementation does not rely on `Interceptor`s to handle the actual retry logic as I personally have found retry logic via `Interceptor`s to be problematic in the past. This could be changed if we find the implementation as written to not be satisfactory.

### 🧪 Testing done
<!-- Feel free to delete this section if it doesn't apply -->
> What testing was added to cover the functionality added in this PR

Unit tests added and passing
