### PR TITLE
fix: loosen collection constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=3.5.0 <4.0.0"
 
 dependencies:
-  collection: ^1.19.0
+  collection: ^1.18.0
   dio: ^5.7.0
   freezed_annotation: ^2.4.4
   uuid: ^4.5.0


### PR DESCRIPTION
### 📰 Summary of changes
<!-- Feel free to delete this section if it doesn't apply -->
> What is the new functionality added in this PR?

Loosens `collection` constraint because 3.24.0 has `collection` 1.18.0 pinned
