### PR TITLE
feat: toString implementation on NetworkResponse

### DIFF
--- a/lib/src/network_response.dart
+++ b/lib/src/network_response.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: public_member_api_docs
 
 import 'package:dio/dio.dart';
+import 'package:equatable/equatable.dart';
 
 /// The produced object after [SturdyHttp] processes a [NetworkRequest].
 ///
@@ -10,7 +11,7 @@ import 'package:dio/dio.dart';
 /// Most often the call sites executing a [NetworkRequest] will only be interested
 /// in a select few of these, and will resolve their error cases via a `maybeWhen`
 /// using the `orElse` clause.
-sealed class NetworkResponse<R> {
+sealed class NetworkResponse<R> extends Equatable {
   const NetworkResponse();
 }
 
@@ -20,12 +21,18 @@ sealed class NetworkResponseSuccess<R> extends NetworkResponse<R> {
 
 final class OkNoContent<R> extends NetworkResponseSuccess<R> {
   const OkNoContent();
+
+  @override
+  List<Object?> get props => [];
 }
 
 final class OkResponse<T> extends NetworkResponseSuccess<T> {
   final T response;
 
   const OkResponse(this.response);
+
+  @override
+  List<Object?> get props => [response];
 }
 
 sealed class NetworkResponseFailure<R> extends NetworkResponse<R> {
@@ -37,6 +44,9 @@ final class Unauthorized<R> extends NetworkResponseFailure<R> {
   final DioException error;
 
   const Unauthorized({required this.error});
+
+  @override
+  List<Object?> get props => [error];
 }
 
 /// 403 - for responses when the request was authenticated but the
@@ -45,6 +55,9 @@ final class Forbidden<R> extends NetworkResponseFailure<R> {
   final DioException error;
 
   const Forbidden({required this.error});
+
+  @override
+  List<Object?> get props => [error];
 }
 
 /// 404 - for responses when we could not locate a resource, or when
@@ -53,6 +66,9 @@ final class NotFound<R> extends NetworkResponseFailure<R> {
   final DioException error;
 
   const NotFound({required this.error});
+
+  @override
+  List<Object?> get props => [error];
 }
 
 /// 422 - for responses when the request inputs failed our validations.
@@ -61,6 +77,9 @@ final class UnprocessableEntity<R> extends NetworkResponseFailure<R> {
   final R response;
 
   const UnprocessableEntity({required this.error, required this.response});
+
+  @override
+  List<Object?> get props => [error, response];
 }
 
 /// 426 - for responses when a client version upgrade is required
@@ -68,6 +87,9 @@ final class UpgradeRequired<R> extends NetworkResponseFailure<R> {
   final DioException error;
 
   const UpgradeRequired({required this.error});
+
+  @override
+  List<Object?> get props => [error];
 }
 
 /// 500 - for responses where the service had an error while processing
@@ -76,6 +98,9 @@ final class ServerError<R> extends NetworkResponseFailure<R> {
   final DioException error;
 
   const ServerError({required this.error});
+
+  @override
+  List<Object?> get props => [error];
 }
 
 /// 503 - for responses when an underlying service issue prevents us from
@@ -84,6 +109,9 @@ final class ServiceUnavailable<R> extends NetworkResponseFailure<R> {
   final DioException error;
 
   const ServiceUnavailable({required this.error});
+
+  @override
+  List<Object?> get props => [error];
 }
 
 /// Any "other" error not covered by the above cases. If a [DioException] is present,
@@ -99,6 +127,9 @@ final class GenericError<R> extends NetworkResponseFailure<R> {
   final DioException? error;
   final String message;
   final bool isConnectionIssue;
+
+  @override
+  List<Object?> get props => [error, message, isConnectionIssue];
 }
 
 /// Extensions on the [NetworkResponse] type

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   collection: ^1.18.0
   dio: ^5.7.0
+  equatable: ^2.0.5
   freezed_annotation: ^2.4.4
   uuid: ^4.5.0
 

--- a/test/src/network_response_test.dart
+++ b/test/src/network_response_test.dart
@@ -1,0 +1,29 @@
+import 'package:dio/dio.dart';
+import 'package:sturdy_http/sturdy_http.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('NetworkResponse', () {
+    test('it has a meaningful toString implementation', () {
+      final subject = GenericError(
+        message: 'Oh no! Something went wrong',
+        isConnectionIssue: true,
+        error: DioException(
+          type: DioExceptionType.unknown,
+          requestOptions: RequestOptions(path: 'https://example.com'),
+          message: 'Blah blah blah',
+          response: Response(
+            requestOptions: RequestOptions(path: 'https://example.com'),
+            statusCode: 500,
+            statusMessage: 'Internal Server Error',
+          ),
+        ),
+      );
+
+      expect(
+        subject.toString(),
+        'GenericError<dynamic>(DioException [unknown]: Blah blah blah, Oh no! Something went wrong, true)',
+      );
+    });
+  });
+}


### PR DESCRIPTION
### 📰 Summary of changes
<!-- Feel free to delete this section if it doesn't apply -->
> What is the new functionality added in this PR?

This PR adds `package:equatable` and makes use of it for simple `toString` implementations on our `NetworkResponse` models. 

This is necessary because we no longer use `package:freezed` for these. I _considered_ removing `freezed` entirely, but figured it was best to keep this PR isolated.

### 🧪 Testing done
<!-- Feel free to delete this section if it doesn't apply -->
> What testing was added to cover the functionality added in this PR

Added test to ensure the `toString` implementation of at least one model remains present.
