### PR TITLE
fix: do not emit DecodingError when response is null

### DIFF
--- a/lib/src/sturdy_http.dart
+++ b/lib/src/sturdy_http.dart
@@ -111,13 +111,17 @@ class SturdyHttp {
         onResponse: onResponse,
       );
     } on Exception catch (e) {
-      await _onEvent(
-        DecodingError(
-          request: responsePayload.dioResponse!.requestOptions,
-          exception: e,
-          stackTrace: StackTrace.current,
-        ),
-      );
+      final response = responsePayload.dioResponse;
+      if (response != null) {
+        await _onEvent(
+          DecodingError(
+            request: response.requestOptions,
+            exception: e,
+            stackTrace: StackTrace.current,
+          ),
+        );
+      }
+
       rethrow;
     }
   }


### PR DESCRIPTION
### 📰 Summary of changes
<!-- Feel free to delete this section if it doesn't apply -->
> What is the new functionality added in this PR?

This PR protects against the case where we get a `DecodingError` when there was no response, which previously caused a null pointer. I think this is actually a fair trade-off, since we can't fail to decode something if there was nothing to decode.

### 🧪 Testing done
<!-- Feel free to delete this section if it doesn't apply -->
> What testing was added to cover the functionality added in this PR

Added a test for the same.